### PR TITLE
added dynamo db delete protectio policy

### DIFF
--- a/docs/policies/dynamo-db-tables-delete-protection-enabled.md
+++ b/docs/policies/dynamo-db-tables-delete-protection-enabled.md
@@ -1,0 +1,65 @@
+#  Amazon Dynamo DB tables should have delete protection enabled
+
+| Provider            | Category     |
+|---------------------|--------------|
+| Amazon Web Services | Storage      |
+
+## Description
+
+This control checks whether an Amazon DynamoDB table has deletion protection enabled. The control fails if a DynamoDB table doesn't have deletion protection enabled.
+
+This rule is covered by the [dynamo-db-tables-delete-protection-enabled](../../policies/dynamo-db-tables-delete-protection-enabled.sentinel) policy.
+
+## Policy Results (Pass)
+```bash
+trace:
+    Pass - dynamo-db-tables-delete-protection-enabled.sentinel
+
+    Description:
+    This policy requires that  `dynamo-db-tables-delete-protection-enabled`
+    attribute of the `aws_dynamodb_table` resource is set to true
+
+    Print messages:
+
+    → → Overall Result: true
+
+    This result means that all resources have passed the policy check for the policy dynamo-db-tables-delete-protection-enabled.
+
+    ✓ Found 0 resource violations
+
+    dynamo-db-tables-delete-protection-enabled.sentinel:46:1 - Rule "main"
+    Value:
+    true
+```
+
+---
+
+## Policy Results (Fail)
+```bash
+trace:
+    Fail - dynamo-db-tables-delete-protection-enabled.sentinel
+
+    Description:
+    This policy requires that  `dynamo-db-tables-delete-protection-enabled`
+    attribute of the `aws_dynamodb_table` resource is set to true
+
+    Print messages:
+
+    → → Overall Result: false
+
+    This result means that not all resources passed the policy check and the protected behavior is not allowed for the policy dynamo-db-tables-delete-protection-enabled.
+
+    Found 1 resource violations
+
+    → Module name: root
+    ↳ Resource Address: aws_dynamodb_table.example
+        | ✗ failed
+        | Attribute 'deletion_protection_enabled' must be set to true for 'aws_dynamodb_table' resources.Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/dynamodb-controls.html#dynamodb-6 for more details.
+
+
+    dynamo-db-tables-delete-protection-enabled.sentinel:46:1 - Rule "main"
+    Value:
+        false
+```
+
+---

--- a/docs/policies/dynamo-db-tables-point-in-time-recovery-enabled.md
+++ b/docs/policies/dynamo-db-tables-point-in-time-recovery-enabled.md
@@ -1,4 +1,4 @@
-#  Amazon Dynamo DB should have point in time recovery enabled
+#  Amazon Dynamo DB tables should have point in time recovery enabled
 
 | Provider            | Category     |
 |---------------------|--------------|

--- a/policies/dynamo-db-tables-delete-protection-enabled.sentinel
+++ b/policies/dynamo-db-tables-delete-protection-enabled.sentinel
@@ -1,0 +1,48 @@
+# This policy requires that  `dynamo-db-tables-delete-protection-enabled` attribute of the `aws_dynamodb_table` resource is set to true
+
+# Imports
+
+import "tfplan/v2" as tfplan
+import "tfresources" as tf
+import "report" as report
+import "collection" as collection
+import "collection/maps" as maps
+
+# Constants
+const = {
+	"policy_name":                 "dynamo-db-tables-delete-protection-enabled",
+	"resource_aws_dynamodb_table": "aws_dynamodb_table",
+}
+
+# Functions
+get_violations = func(resources) {
+	return collection.reject(resources, func(res) {
+		return maps.get(res, "values.deletion_protection_enabled", false) is true
+	})
+}
+
+# Variables
+
+aws_dynamodb_tables = tf.plan(tfplan.planned_values.resources).type(const.resource_aws_dynamodb_table).resources
+violations = get_violations(aws_dynamodb_tables)
+
+summary = {
+	"policy_name": const.policy_name,
+	"violations": map violations as _, v {
+		{
+			"address":        v.address,
+			"module_address": v.module_address,
+			"message":        "Attribute 'deletion_protection_enabled' must be set to true for 'aws_dynamodb_table' resources.Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/dynamodb-controls.html#dynamodb-6 for more details.",
+		}
+	},
+}
+
+# Outputs
+
+print(report.generate_policy_report(summary))
+
+# Rules
+
+main = rule {
+	violations is empty
+}

--- a/policies/test/dynamo-db-tables-delete-protection-enabled/failure-delete-protection-disabled.hcl
+++ b/policies/test/dynamo-db-tables-delete-protection-enabled/failure-delete-protection-disabled.hcl
@@ -1,0 +1,21 @@
+mock "tfplan/v2" {
+  module {
+    source = "./mocks/failure-delete-protection-disabled/mock-tfplan-v2.sentinel"
+  }
+}
+
+import "plugin" "tfresources" {
+  source = "../../../plugins/darwin/arm64/sentinel-plugin-tfresources"
+}
+
+mock "report" {
+  module {
+    source = "../../../modules/mocks/report/report.sentinel"
+  }
+}
+
+test {
+  rules = {
+    main = false
+  }
+}

--- a/policies/test/dynamo-db-tables-delete-protection-enabled/failure-delete-protection-null.hcl
+++ b/policies/test/dynamo-db-tables-delete-protection-enabled/failure-delete-protection-null.hcl
@@ -1,0 +1,21 @@
+mock "tfplan/v2" {
+  module {
+    source = "./mocks/failure-delete-protection-null/mock-tfplan-v2.sentinel"
+  }
+}
+
+import "plugin" "tfresources" {
+  source = "../../../plugins/darwin/arm64/sentinel-plugin-tfresources"
+}
+
+mock "report" {
+  module {
+    source = "../../../modules/mocks/report/report.sentinel"
+  }
+}
+
+test {
+  rules = {
+    main = false
+  }
+}

--- a/policies/test/dynamo-db-tables-delete-protection-enabled/mocks/failure-delete-protection-disabled/mock-tfplan-v2.sentinel
+++ b/policies/test/dynamo-db-tables-delete-protection-enabled/mocks/failure-delete-protection-disabled/mock-tfplan-v2.sentinel
@@ -1,0 +1,60 @@
+terraform_version = "1.7.4"
+
+planned_values = {
+	"outputs": {},
+	"resources": {
+		"aws_dynamodb_table.example": {
+			"address":        "aws_dynamodb_table.example",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "example",
+			"provider_name":  "registry.terraform.io/hashicorp/aws",
+			"tainted":        false,
+			"type":           "aws_dynamodb_table",
+			"values": {
+				"attribute": [
+					{
+						"name": "TestTableHashKey",
+						"type": "S",
+					},
+				],
+				"billing_mode":                "PAY_PER_REQUEST",
+				"deletion_protection_enabled": false,
+				"global_secondary_index":      [],
+				"hash_key":                    "TestTableHashKey",
+				"import_table":                [],
+				"local_secondary_index":       [],
+				"name":                        "example",
+				"point_in_time_recovery": [
+					{
+						"enabled": false,
+					},
+				],
+				"range_key": null,
+				"replica": [
+					{
+						"point_in_time_recovery": false,
+						"propagate_tags":         false,
+						"region_name":            "us-east-2",
+					},
+					{
+						"point_in_time_recovery": false,
+						"propagate_tags":         false,
+						"region_name":            "us-west-2",
+					},
+				],
+				"restore_date_time":      null,
+				"restore_source_name":    null,
+				"restore_to_latest_time": null,
+				"stream_enabled":         true,
+				"stream_view_type":       "NEW_AND_OLD_IMAGES",
+				"table_class":            null,
+				"tags":                   null,
+				"timeouts":               null,
+			},
+		},
+	},
+}

--- a/policies/test/dynamo-db-tables-delete-protection-enabled/mocks/failure-delete-protection-null/mock-tfplan-v2.sentinel
+++ b/policies/test/dynamo-db-tables-delete-protection-enabled/mocks/failure-delete-protection-null/mock-tfplan-v2.sentinel
@@ -1,0 +1,55 @@
+terraform_version = "1.7.4"
+
+planned_values = {
+	"outputs": {},
+	"resources": {
+		"aws_dynamodb_table.example": {
+			"address":        "aws_dynamodb_table.example",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "example",
+			"provider_name":  "registry.terraform.io/hashicorp/aws",
+			"tainted":        false,
+			"type":           "aws_dynamodb_table",
+			"values": {
+				"attribute": [
+					{
+						"name": "TestTableHashKey",
+						"type": "S",
+					},
+				],
+				"billing_mode":                "PAY_PER_REQUEST",
+				"deletion_protection_enabled": null,
+				"global_secondary_index":      [],
+				"hash_key":                    "TestTableHashKey",
+				"import_table":                [],
+				"local_secondary_index":       [],
+				"name":                        "example",
+				"range_key":                   null,
+				"replica": [
+					{
+						"point_in_time_recovery": false,
+						"propagate_tags":         false,
+						"region_name":            "us-east-2",
+					},
+					{
+						"point_in_time_recovery": false,
+						"propagate_tags":         false,
+						"region_name":            "us-west-2",
+					},
+				],
+				"restore_date_time":      null,
+				"restore_source_name":    null,
+				"restore_to_latest_time": null,
+				"stream_enabled":         true,
+				"stream_view_type":       "NEW_AND_OLD_IMAGES",
+				"table_class":            null,
+				"tags":                   null,
+				"timeouts":               null,
+			},
+		},
+	},
+}

--- a/policies/test/dynamo-db-tables-delete-protection-enabled/mocks/success/mock-tfplan-v2.sentinel
+++ b/policies/test/dynamo-db-tables-delete-protection-enabled/mocks/success/mock-tfplan-v2.sentinel
@@ -1,0 +1,60 @@
+terraform_version = "1.7.4"
+
+planned_values = {
+	"outputs": {},
+	"resources": {
+		"aws_dynamodb_table.example": {
+			"address":        "aws_dynamodb_table.example",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "example",
+			"provider_name":  "registry.terraform.io/hashicorp/aws",
+			"tainted":        false,
+			"type":           "aws_dynamodb_table",
+			"values": {
+				"attribute": [
+					{
+						"name": "TestTableHashKey",
+						"type": "S",
+					},
+				],
+				"billing_mode":                "PAY_PER_REQUEST",
+				"deletion_protection_enabled": true,
+				"global_secondary_index":      [],
+				"hash_key":                    "TestTableHashKey",
+				"import_table":                [],
+				"local_secondary_index":       [],
+				"name":                        "example",
+				"point_in_time_recovery": [
+					{
+						"enabled": true,
+					},
+				],
+				"range_key": null,
+				"replica": [
+					{
+						"point_in_time_recovery": false,
+						"propagate_tags":         false,
+						"region_name":            "us-east-2",
+					},
+					{
+						"point_in_time_recovery": false,
+						"propagate_tags":         false,
+						"region_name":            "us-west-2",
+					},
+				],
+				"restore_date_time":      null,
+				"restore_source_name":    null,
+				"restore_to_latest_time": null,
+				"stream_enabled":         true,
+				"stream_view_type":       "NEW_AND_OLD_IMAGES",
+				"table_class":            null,
+				"tags":                   null,
+				"timeouts":               null,
+			},
+		},
+	},
+}

--- a/policies/test/dynamo-db-tables-delete-protection-enabled/success.hcl
+++ b/policies/test/dynamo-db-tables-delete-protection-enabled/success.hcl
@@ -1,0 +1,21 @@
+mock "tfplan/v2" {
+  module {
+    source = "./mocks/success/mock-tfplan-v2.sentinel"
+  }
+}
+
+import "plugin" "tfresources" {
+  source = "../../../plugins/darwin/arm64/sentinel-plugin-tfresources"
+}
+
+mock "report" {
+  module {
+    source = "../../../modules/mocks/report/report.sentinel"
+  }
+}
+
+test {
+  rules = {
+    main = true
+  }
+}

--- a/sentinel.hcl
+++ b/sentinel.hcl
@@ -102,3 +102,8 @@ policy "dynamo-db-accelerator-clusters-encryption-at-rest-enabled" {
   source = "./policies/dynamo-db-accelerator-clusters-encryption-at-rest-enabled.sentinel"
   enforcement_level = "advisory"
 }
+
+policy "dynamo-db-tables-delete-protection-enabled" {
+  source = "./policies/dynamo-db-tables-delete-protection-enabled.sentinel"
+  enforcement_level = "advisory"
+}

--- a/tests/acceptance/dynamo-db-tables-delete-protection-enabled/cases/delete-protection-disabled/backend.tf
+++ b/tests/acceptance/dynamo-db-tables-delete-protection-enabled/cases/delete-protection-disabled/backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  cloud {
+    workspaces {
+      name = "dynamo-db-tables-delete-protection-enabled"
+    }
+  }
+}

--- a/tests/acceptance/dynamo-db-tables-delete-protection-enabled/cases/delete-protection-disabled/main.tf
+++ b/tests/acceptance/dynamo-db-tables-delete-protection-enabled/cases/delete-protection-disabled/main.tf
@@ -1,0 +1,27 @@
+provider "aws" {
+  region = "us-west-2"
+}
+
+resource "aws_dynamodb_table" "example" {
+  name             = "example"
+  hash_key         = "TestTableHashKey"
+  billing_mode     = "PAY_PER_REQUEST"
+  stream_enabled   = true
+  stream_view_type = "NEW_AND_OLD_IMAGES"
+  point_in_time_recovery {
+    enabled = false
+  }
+  attribute {
+    name = "TestTableHashKey"
+    type = "S"
+  }
+
+  replica {
+    region_name = "us-east-2"
+  }
+
+  replica {
+    region_name = "us-west-2"
+  }
+  deletion_protection_enabled = false
+}

--- a/tests/acceptance/dynamo-db-tables-delete-protection-enabled/cases/delete-protection-enabled-nested-module/backend.tf
+++ b/tests/acceptance/dynamo-db-tables-delete-protection-enabled/cases/delete-protection-enabled-nested-module/backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  cloud {
+    workspaces {
+      name = "dynamo-db-tables-delete-protection-enabled"
+    }
+  }
+}

--- a/tests/acceptance/dynamo-db-tables-delete-protection-enabled/cases/delete-protection-enabled-nested-module/dynamo-db/main.tf
+++ b/tests/acceptance/dynamo-db-tables-delete-protection-enabled/cases/delete-protection-enabled-nested-module/dynamo-db/main.tf
@@ -1,0 +1,23 @@
+resource "aws_dynamodb_table" "example" {
+  name             = "example"
+  hash_key         = "TestTableHashKey"
+  billing_mode     = "PAY_PER_REQUEST"
+  stream_enabled   = true
+  stream_view_type = "NEW_AND_OLD_IMAGES"
+  point_in_time_recovery {
+    enabled = true
+  }
+  attribute {
+    name = "TestTableHashKey"
+    type = "S"
+  }
+
+  replica {
+    region_name = "us-east-2"
+  }
+
+  replica {
+    region_name = "us-west-2"
+  }
+  deletion_protection_enabled = true
+}

--- a/tests/acceptance/dynamo-db-tables-delete-protection-enabled/cases/delete-protection-enabled-nested-module/main.tf
+++ b/tests/acceptance/dynamo-db-tables-delete-protection-enabled/cases/delete-protection-enabled-nested-module/main.tf
@@ -1,0 +1,7 @@
+provider "aws" {
+  region = "us-west-2"
+}
+
+module "dynamo_db" {
+  source = "./dynamo-db"
+}

--- a/tests/acceptance/dynamo-db-tables-delete-protection-enabled/cases/delete-protection-enabled/backend.tf
+++ b/tests/acceptance/dynamo-db-tables-delete-protection-enabled/cases/delete-protection-enabled/backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  cloud {
+    workspaces {
+      name = "dynamo-db-tables-delete-protection-enabled"
+    }
+  }
+}

--- a/tests/acceptance/dynamo-db-tables-delete-protection-enabled/cases/delete-protection-enabled/main.tf
+++ b/tests/acceptance/dynamo-db-tables-delete-protection-enabled/cases/delete-protection-enabled/main.tf
@@ -1,0 +1,27 @@
+provider "aws" {
+  region = "us-west-2"
+}
+
+resource "aws_dynamodb_table" "example" {
+  name             = "example"
+  hash_key         = "TestTableHashKey"
+  billing_mode     = "PAY_PER_REQUEST"
+  stream_enabled   = true
+  stream_view_type = "NEW_AND_OLD_IMAGES"
+  point_in_time_recovery {
+    enabled = true
+  }
+  attribute {
+    name = "TestTableHashKey"
+    type = "S"
+  }
+
+  replica {
+    region_name = "us-east-2"
+  }
+
+  replica {
+    region_name = "us-west-2"
+  }
+  deletion_protection_enabled = true
+}

--- a/tests/acceptance/dynamo-db-tables-delete-protection-enabled/cases/delete-protection-undefined/backend.tf
+++ b/tests/acceptance/dynamo-db-tables-delete-protection-enabled/cases/delete-protection-undefined/backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  cloud {
+    workspaces {
+      name = "dynamo-db-tables-delete-protection-enabled"
+    }
+  }
+}

--- a/tests/acceptance/dynamo-db-tables-delete-protection-enabled/cases/delete-protection-undefined/main.tf
+++ b/tests/acceptance/dynamo-db-tables-delete-protection-enabled/cases/delete-protection-undefined/main.tf
@@ -1,0 +1,23 @@
+provider "aws" {
+  region = "us-west-2"
+}
+
+resource "aws_dynamodb_table" "example" {
+  name             = "example"
+  hash_key         = "TestTableHashKey"
+  billing_mode     = "PAY_PER_REQUEST"
+  stream_enabled   = true
+  stream_view_type = "NEW_AND_OLD_IMAGES"
+  attribute {
+    name = "TestTableHashKey"
+    type = "S"
+  }
+
+  replica {
+    region_name = "us-east-2"
+  }
+
+  replica {
+    region_name = "us-west-2"
+  }
+}

--- a/tests/acceptance/dynamo-db-tables-delete-protection-enabled/test-config.hcl
+++ b/tests/acceptance/dynamo-db-tables-delete-protection-enabled/test-config.hcl
@@ -1,0 +1,31 @@
+name = "dynamo-db-tables-delete-protection-enabled"
+
+disabled = false
+
+case "Delete protection enabled" {
+    path = "./cases/delete-protection-enabled"
+    expectation {
+        result = true
+    }
+}
+
+case "Delete protection enabled nested module" {
+    path = "./cases/delete-protection-enabled-nested-module"
+    expectation {
+        result = true
+    }
+}
+
+case "Delete protection disabled" {
+    path = "./cases/delete-protection-disabled"
+    expectation {
+        result = false
+    }
+}
+
+case "Delete protection undefined" {
+    path = "./cases/delete-protection-undefined"
+    expectation {
+        result = false
+    }
+}


### PR DESCRIPTION
## Changes proposed in this PR:
- added dynamo db delete protectio policy
-

## Documentation
- [AWS Standard](https://docs.aws.amazon.com/securityhub/latest/userguide/dynamodb-controls.html#dynamodb-6)

## AWS Provider version
<!-- Add information about the provider version against which the policy was tested/developed with. This will later help us when we deal with documentation.Add any nuances that you've observed around provider versions. For example, some attributes will only be present in a certain version of a provider and we need to clearly document that so that users use the expected version.-->

## How I've tested this PR:

## Checklist:
- [x] Tests added