### PR TITLE
added  elasticbeanstalk platform updates policy

### DIFF
--- a/docs/policies/elasticbeanstalk-managed-platform-updates-enabled.md
+++ b/docs/policies/elasticbeanstalk-managed-platform-updates-enabled.md
@@ -1,0 +1,63 @@
+#  Amazon Elastic Beanstalk environments should have managed platform updates enabled
+
+| Provider            | Category                    |
+|---------------------|-----------------------------|
+| Amazon Web Services | Application monitoring      |
+
+## Description
+
+This control checks whether managed platform updates are enabled for an Elastic Beanstalk environment. The control fails if no managed platform updates are enabled.
+
+This rule is covered by the [elasticbeanstalk-managed-platform-updates-enabled](../../policies/elasticbeanstalk-managed-platform-updates-enabled.sentinel) policy.
+
+## Policy Results (Pass)
+```bash
+trace:
+    Pass - elasticbeanstalk-managed-platform-updates-enabled.sentinel
+
+    Description:
+    This policy requires that the elasticbeanstalk environment have platform updates enabled
+
+    Print messages:
+
+    → → Overall Result: true
+
+    This result means that all resources have passed the policy check for the policy elasticbeanstalk-managed-platform-updates-enabled.
+
+    ✓ Found 0 resource violations
+
+    elasticbeanstalk-managed-platform-updates-enabled.sentinel:54:1 - Rule "main"
+    Value:
+        true
+```
+
+---
+
+## Policy Results (Fail)
+```bash
+trace:
+    Fail - elasticbeanstalk-managed-platform-updates-enabled.sentinel
+
+    Description:
+    This policy requires that the elasticbeanstalk environment have platform updates enabled
+
+    Print messages:
+
+    → → Overall Result: false
+
+    This result means that not all resources passed the policy check and the protected behavior is not allowed for the policy elasticbeanstalk-managed-platform-updates-enabled.
+
+    Found 1 resource violations
+
+    → Module name: root
+    ↳ Resource Address: aws_elastic_beanstalk_environment.example
+        | ✗ failed
+        | Elastic Beanstalk environment does not have platform updates enabled. Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/elasticbeanstalk-controls.html#elasticbeanstalk-2 for more details.
+
+
+    elasticbeanstalk-managed-platform-updates-enabled.sentinel:54:1 - Rule "main"
+    Value:
+        false
+```
+
+---

--- a/policies/elasticbeanstalk-managed-platform-updates-enabled.sentinel
+++ b/policies/elasticbeanstalk-managed-platform-updates-enabled.sentinel
@@ -1,0 +1,57 @@
+# This policy requires that the elasticbeanstalk environment have platform updates enabled
+
+# Imports
+
+import "tfplan/v2" as tfplan
+import "tfresources" as tf
+import "report" as report
+import "collection" as collection
+import "collection/maps" as maps
+
+# Constants
+const = {
+	"policy_name":                                "elasticbeanstalk-managed-platform-updates-enabled",
+	"resource_aws_elastic_beanstalk_environment": "aws_elastic_beanstalk_environment",
+}
+
+# Functions
+
+exists_setting_with_value = func(settings, namespace, name, value) {
+	return collection.find(settings, func(setting) {
+		return setting.namespace is namespace and
+			setting.name is name and
+			setting.value is value
+	}) is defined
+}
+
+get_violations = func(resources) {
+	return collection.reject(resources, func(res) {
+		settings = maps.get(res.values, "setting", [])
+		return exists_setting_with_value(settings, "aws:elasticbeanstalk:managedactions", "ManagedActionsEnabled", "true") and
+			(exists_setting_with_value(settings, "aws:elasticbeanstalk:managedactions:platformupdate", "UpdateLevel", "minor") or
+				exists_setting_with_value(settings, "aws:elasticbeanstalk:managedactions:platformupdate", "UpdateLevel", "patch"))
+	})
+}
+
+# Variables
+resources = tf.plan(tfplan.planned_values.resources).type(const.resource_aws_elastic_beanstalk_environment).resources
+violations = get_violations(resources)
+
+summary = {
+	"policy_name": const.policy_name,
+	"violations": map violations as _, v {
+		{
+			"address":        v.address,
+			"module_address": v.module_address,
+			"message":        "Elastic Beanstalk environment does not have platform updates enabled. Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/elasticbeanstalk-controls.html#elasticbeanstalk-2 for more details.",
+		}
+	},
+}
+
+# Outputs
+
+print(report.generate_policy_report(summary))
+
+main = rule {
+	violations is empty
+}

--- a/policies/test/elasticbeanstalk-managed-platform-updates-enabled/failure-enhance-helthcheck-disabled.hcl
+++ b/policies/test/elasticbeanstalk-managed-platform-updates-enabled/failure-enhance-helthcheck-disabled.hcl
@@ -1,0 +1,21 @@
+mock "tfplan/v2" {
+  module {
+    source = "./mocks/failure-managed-actions-disabled/mock-tfplan-v2.sentinel"
+  }
+}
+
+import "plugin" "tfresources" {
+  source = "../../../plugins/darwin/arm64/sentinel-plugin-tfresources"
+}
+
+mock "report" {
+  module {
+    source = "../../../modules/mocks/report/report.sentinel"
+  }
+}
+
+test {
+  rules = {
+    main = false
+  }
+}

--- a/policies/test/elasticbeanstalk-managed-platform-updates-enabled/failure-helth-setting-is-not-found.hcl
+++ b/policies/test/elasticbeanstalk-managed-platform-updates-enabled/failure-helth-setting-is-not-found.hcl
@@ -1,0 +1,21 @@
+mock "tfplan/v2" {
+  module {
+    source = "./mocks/failure-update-setting-not-found/mock-tfplan-v2.sentinel"
+  }
+}
+
+import "plugin" "tfresources" {
+  source = "../../../plugins/darwin/arm64/sentinel-plugin-tfresources"
+}
+
+mock "report" {
+  module {
+    source = "../../../modules/mocks/report/report.sentinel"
+  }
+}
+
+test {
+  rules = {
+    main = false
+  }
+}

--- a/policies/test/elasticbeanstalk-managed-platform-updates-enabled/mocks/failure-managed-actions-disabled/mock-tfplan-v2.sentinel
+++ b/policies/test/elasticbeanstalk-managed-platform-updates-enabled/mocks/failure-managed-actions-disabled/mock-tfplan-v2.sentinel
@@ -1,0 +1,68 @@
+terraform_version = "1.7.4"
+
+planned_values = {
+	"outputs": {},
+	"resources": {
+		"aws_elastic_beanstalk_application.example": {
+			"address":        "aws_elastic_beanstalk_application.example",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "example",
+			"provider_name":  "registry.terraform.io/hashicorp/aws",
+			"tainted":        false,
+			"type":           "aws_elastic_beanstalk_application",
+			"values": {
+				"appversion_lifecycle": [],
+				"description":          "An example Elastic Beanstalk application",
+				"name":                 "example-app",
+				"tags":                 null,
+			},
+		},
+		"aws_elastic_beanstalk_environment.example": {
+			"address":        "aws_elastic_beanstalk_environment.example",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "example",
+			"provider_name":  "registry.terraform.io/hashicorp/aws",
+			"tainted":        false,
+			"type":           "aws_elastic_beanstalk_environment",
+			"values": {
+				"application":   "example-app",
+				"description":   null,
+				"name":          "example-env",
+				"poll_interval": null,
+				"setting": [
+					{
+						"name":      "EnvironmentType",
+						"namespace": "aws:elasticbeanstalk:environment",
+						"resource":  "",
+						"value":     "LoadBalanced",
+					},
+					{
+						"name":      "InstanceType",
+						"namespace": "aws:autoscaling:launchconfiguration",
+						"resource":  "",
+						"value":     "t2.micro",
+					},
+					{
+						"name":      "ManagedActionsEnabled",
+						"namespace": "aws:elasticbeanstalk:managedactions",
+						"resource":  "",
+						"value":     "false",
+					},
+				],
+				"solution_stack_name": "64bit Amazon Linux 2 v3.3.10 running Python 3.8",
+				"tags":                null,
+				"template_name":       null,
+				"tier":                "WebServer",
+				"wait_for_ready_timeout": "20m",
+			},
+		},
+	},
+}

--- a/policies/test/elasticbeanstalk-managed-platform-updates-enabled/mocks/failure-update-setting-not-found/mock-tfplan-v2.sentinel
+++ b/policies/test/elasticbeanstalk-managed-platform-updates-enabled/mocks/failure-update-setting-not-found/mock-tfplan-v2.sentinel
@@ -1,0 +1,74 @@
+terraform_version = "1.7.4"
+
+planned_values = {
+	"outputs": {},
+	"resources": {
+		"aws_elastic_beanstalk_application.example": {
+			"address":        "aws_elastic_beanstalk_application.example",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "example",
+			"provider_name":  "registry.terraform.io/hashicorp/aws",
+			"tainted":        false,
+			"type":           "aws_elastic_beanstalk_application",
+			"values": {
+				"appversion_lifecycle": [],
+				"description":          "An example Elastic Beanstalk application",
+				"name":                 "example-app",
+				"tags":                 null,
+			},
+		},
+		"aws_elastic_beanstalk_environment.example": {
+			"address":        "aws_elastic_beanstalk_environment.example",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "example",
+			"provider_name":  "registry.terraform.io/hashicorp/aws",
+			"tainted":        false,
+			"type":           "aws_elastic_beanstalk_environment",
+			"values": {
+				"application":   "example-app",
+				"description":   null,
+				"name":          "example-env",
+				"poll_interval": null,
+				"setting": [
+					{
+						"name":      "EnvironmentType",
+						"namespace": "aws:elasticbeanstalk:environment",
+						"resource":  "",
+						"value":     "LoadBalanced",
+					},
+					{
+						"name":      "InstanceType",
+						"namespace": "aws:autoscaling:launchconfiguration",
+						"resource":  "",
+						"value":     "t2.micro",
+					},
+					{
+						"name":      "SystemType",
+						"namespace": "aws:elasticbeanstalk:healthreporting:system",
+						"resource":  "",
+						"value":     "basic",
+					},
+					{
+						"name":      "ManagedActionsEnabled",
+						"namespace": "aws:elasticbeanstalk:managedactions",
+						"resource":  "",
+						"value":     "true",
+					},
+				],
+				"solution_stack_name": "64bit Amazon Linux 2 v3.3.10 running Python 3.8",
+				"tags":                null,
+				"template_name":       null,
+				"tier":                "WebServer",
+				"wait_for_ready_timeout": "20m",
+			},
+		},
+	},
+}

--- a/policies/test/elasticbeanstalk-managed-platform-updates-enabled/mocks/success/mock-tfplan-v2.sentinel
+++ b/policies/test/elasticbeanstalk-managed-platform-updates-enabled/mocks/success/mock-tfplan-v2.sentinel
@@ -1,0 +1,80 @@
+terraform_version = "1.7.4"
+
+planned_values = {
+	"outputs": {},
+	"resources": {
+		"aws_elastic_beanstalk_application.example": {
+			"address":        "aws_elastic_beanstalk_application.example",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "example",
+			"provider_name":  "registry.terraform.io/hashicorp/aws",
+			"tainted":        false,
+			"type":           "aws_elastic_beanstalk_application",
+			"values": {
+				"appversion_lifecycle": [],
+				"description":          "An example Elastic Beanstalk application",
+				"name":                 "example-app",
+				"tags":                 null,
+			},
+		},
+		"aws_elastic_beanstalk_environment.example": {
+			"address":        "aws_elastic_beanstalk_environment.example",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "example",
+			"provider_name":  "registry.terraform.io/hashicorp/aws",
+			"tainted":        false,
+			"type":           "aws_elastic_beanstalk_environment",
+			"values": {
+				"application":   "example-app",
+				"description":   null,
+				"name":          "example-env",
+				"poll_interval": null,
+				"setting": [
+					{
+						"name":      "EnvironmentType",
+						"namespace": "aws:elasticbeanstalk:environment",
+						"resource":  "",
+						"value":     "LoadBalanced",
+					},
+					{
+						"name":      "InstanceType",
+						"namespace": "aws:autoscaling:launchconfiguration",
+						"resource":  "",
+						"value":     "t2.micro",
+					},
+					{
+						"name":      "SystemType",
+						"namespace": "aws:elasticbeanstalk:healthreporting:system",
+						"resource":  "",
+						"value":     "enhanced",
+					},
+					{
+						"name":      "ManagedActionsEnabled",
+						"namespace": "aws:elasticbeanstalk:managedactions",
+						"resource":  "",
+						"value":     "true",
+					},
+					{
+						"name":      "UpdateLevel",
+						"namespace": "aws:elasticbeanstalk:managedactions:platformupdate",
+						"resource":  "",
+						"value":     "patch",
+					},
+				],
+				"solution_stack_name": "64bit Amazon Linux 2 v3.3.10 running Python 3.8",
+				"tags":                null,
+				"template_name":       null,
+				"tier":                "WebServer",
+				"wait_for_ready_timeout": "20m",
+			},
+		},
+	},
+}

--- a/policies/test/elasticbeanstalk-managed-platform-updates-enabled/success.hcl
+++ b/policies/test/elasticbeanstalk-managed-platform-updates-enabled/success.hcl
@@ -1,0 +1,21 @@
+mock "tfplan/v2" {
+  module {
+    source = "./mocks/success/mock-tfplan-v2.sentinel"
+  }
+}
+
+import "plugin" "tfresources" {
+  source = "../../../plugins/darwin/arm64/sentinel-plugin-tfresources"
+}
+
+mock "report" {
+  module {
+    source = "../../../modules/mocks/report/report.sentinel"
+  }
+}
+
+test {
+  rules = {
+    main = true
+  }
+}

--- a/sentinel.hcl
+++ b/sentinel.hcl
@@ -177,3 +177,8 @@ policy "dynamo-db-tables-scales-capacity-with-demand" {
       max_target_write_utilization = 90
  }
 }
+
+policy "elasticbeanstalk-managed-platform-updates-enabled" {
+  source = "./policies/elasticbeanstalk-managed-platform-updates-enabled.sentinel"
+  enforcement_level = "advisory"
+}

--- a/tests/acceptance/elasticbeanstalk-managed-platform-updates-enabled/cases/all-resources-complaint/backend.tf
+++ b/tests/acceptance/elasticbeanstalk-managed-platform-updates-enabled/cases/all-resources-complaint/backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  cloud {
+    workspaces {
+      name = "elasticbeanstalk-managed-platform-updates-enabled"
+    }
+  }
+}

--- a/tests/acceptance/elasticbeanstalk-managed-platform-updates-enabled/cases/all-resources-complaint/main.tf
+++ b/tests/acceptance/elasticbeanstalk-managed-platform-updates-enabled/cases/all-resources-complaint/main.tf
@@ -1,0 +1,33 @@
+provider "aws" {
+  region = "us-west-2"
+}
+
+resource "aws_elastic_beanstalk_application" "example" {
+  name        = "example-app"
+  description = "An example Elastic Beanstalk application"
+}
+
+resource "aws_elastic_beanstalk_environment" "example" {
+  name                = "example-env"
+  application         = aws_elastic_beanstalk_application.example.name
+  solution_stack_name = "64bit Amazon Linux 2 v3.3.10 running Python 3.8"
+
+  setting {
+    namespace = "aws:elasticbeanstalk:healthreporting:system"
+    name      = "SystemType"
+    value     = "enhanced"
+  }
+
+  setting {
+    namespace = "aws:elasticbeanstalk:managedactions"
+    name      = "ManagedActionsEnabled"
+    value     = "true"
+  }
+
+  setting {
+    namespace = "aws:elasticbeanstalk:managedactions:platformupdate"
+    name      = "UpdateLevel"
+    value     = "minor"
+  }
+
+}

--- a/tests/acceptance/elasticbeanstalk-managed-platform-updates-enabled/cases/all-resources-compliant-nested-modules/backend.tf
+++ b/tests/acceptance/elasticbeanstalk-managed-platform-updates-enabled/cases/all-resources-compliant-nested-modules/backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  cloud {
+    workspaces {
+      name = "elasticbeanstalk-managed-platform-updates-enabled"
+    }
+  }
+}

--- a/tests/acceptance/elasticbeanstalk-managed-platform-updates-enabled/cases/all-resources-compliant-nested-modules/elasticbeanstalk-managed-platform-updates-enabled/main.tf
+++ b/tests/acceptance/elasticbeanstalk-managed-platform-updates-enabled/cases/all-resources-compliant-nested-modules/elasticbeanstalk-managed-platform-updates-enabled/main.tf
@@ -1,0 +1,27 @@
+resource "aws_elastic_beanstalk_application" "example" {
+  name        = "example-app"
+  description = "An example Elastic Beanstalk application"
+}
+
+resource "aws_elastic_beanstalk_environment" "example" {
+  name                = "example-env"
+  application         = aws_elastic_beanstalk_application.example.name
+  solution_stack_name = "64bit Amazon Linux 2 v3.3.10 running Python 3.8"
+
+  setting {
+    namespace = "aws:elasticbeanstalk:healthreporting:system"
+    name      = "SystemType"
+    value     = "enhanced"
+  }
+  setting {
+    namespace = "aws:elasticbeanstalk:managedactions"
+    name      = "ManagedActionsEnabled"
+    value     = "true"
+  }
+
+  setting {
+    namespace = "aws:elasticbeanstalk:managedactions:platformupdate"
+    name      = "UpdateLevel"
+    value     = "minor"
+  }
+}

--- a/tests/acceptance/elasticbeanstalk-managed-platform-updates-enabled/cases/all-resources-compliant-nested-modules/main.tf
+++ b/tests/acceptance/elasticbeanstalk-managed-platform-updates-enabled/cases/all-resources-compliant-nested-modules/main.tf
@@ -1,0 +1,8 @@
+provider "aws" {
+  region = "us-west-2"
+}
+
+
+module "elasticbeanstalk-healthreporting" {
+  source = "./elasticbeanstalk-managed-platform-updates-enabled"
+}

--- a/tests/acceptance/elasticbeanstalk-managed-platform-updates-enabled/cases/elasticbeanstalk-environment-setting-undefined/backend.tf
+++ b/tests/acceptance/elasticbeanstalk-managed-platform-updates-enabled/cases/elasticbeanstalk-environment-setting-undefined/backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  cloud {
+    workspaces {
+      name = "elasticbeanstalk-managed-platform-updates-enabled"
+    }
+  }
+}

--- a/tests/acceptance/elasticbeanstalk-managed-platform-updates-enabled/cases/elasticbeanstalk-environment-setting-undefined/main.tf
+++ b/tests/acceptance/elasticbeanstalk-managed-platform-updates-enabled/cases/elasticbeanstalk-environment-setting-undefined/main.tf
@@ -1,0 +1,14 @@
+provider "aws" {
+  region = "us-west-2"
+}
+
+resource "aws_elastic_beanstalk_application" "example" {
+  name        = "example-app"
+  description = "An example Elastic Beanstalk application"
+}
+
+resource "aws_elastic_beanstalk_environment" "example" {
+  name                = "example-env"
+  application         = aws_elastic_beanstalk_application.example.name
+  solution_stack_name = "64bit Amazon Linux 2 v3.3.10 running Python 3.8"
+}

--- a/tests/acceptance/elasticbeanstalk-managed-platform-updates-enabled/cases/elasticbeanstalk-managed-actions-disabled/backend.tf
+++ b/tests/acceptance/elasticbeanstalk-managed-platform-updates-enabled/cases/elasticbeanstalk-managed-actions-disabled/backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  cloud {
+    workspaces {
+      name = "elasticbeanstalk-managed-platform-updates-enabled"
+    }
+  }
+}

--- a/tests/acceptance/elasticbeanstalk-managed-platform-updates-enabled/cases/elasticbeanstalk-managed-actions-disabled/main.tf
+++ b/tests/acceptance/elasticbeanstalk-managed-platform-updates-enabled/cases/elasticbeanstalk-managed-actions-disabled/main.tf
@@ -1,0 +1,33 @@
+provider "aws" {
+  region = "us-west-2"
+}
+
+resource "aws_elastic_beanstalk_application" "example" {
+  name        = "example-app"
+  description = "An example Elastic Beanstalk application"
+}
+
+resource "aws_elastic_beanstalk_environment" "example" {
+  name                = "example-env"
+  application         = aws_elastic_beanstalk_application.example.name
+  solution_stack_name = "64bit Amazon Linux 2 v3.3.10 running Python 3.8"
+
+  setting {
+    namespace = "aws:elasticbeanstalk:healthreporting:system"
+    name      = "SystemType"
+    value     = "enhanced"
+  }
+
+  setting {
+    namespace = "aws:elasticbeanstalk:managedactions"
+    name      = "ManagedActionsEnabled"
+    value     = "false"
+  }
+
+  setting {
+    namespace = "aws:elasticbeanstalk:managedactions:platformupdate"
+    name      = "UpdateLevel"
+    value     = "minor"
+  }
+
+}

--- a/tests/acceptance/elasticbeanstalk-managed-platform-updates-enabled/cases/elasticbeanstalk-platform-updates-disabled/backend.tf
+++ b/tests/acceptance/elasticbeanstalk-managed-platform-updates-enabled/cases/elasticbeanstalk-platform-updates-disabled/backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  cloud {
+    workspaces {
+      name = "elasticbeanstalk-managed-platform-updates-enabled"
+    }
+  }
+}

--- a/tests/acceptance/elasticbeanstalk-managed-platform-updates-enabled/cases/elasticbeanstalk-platform-updates-disabled/main.tf
+++ b/tests/acceptance/elasticbeanstalk-managed-platform-updates-enabled/cases/elasticbeanstalk-platform-updates-disabled/main.tf
@@ -1,0 +1,27 @@
+provider "aws" {
+  region = "us-west-2"
+}
+
+resource "aws_elastic_beanstalk_application" "example" {
+  name        = "example-app"
+  description = "An example Elastic Beanstalk application"
+}
+
+resource "aws_elastic_beanstalk_environment" "example" {
+  name                = "example-env"
+  application         = aws_elastic_beanstalk_application.example.name
+  solution_stack_name = "64bit Amazon Linux 2 v3.3.10 running Python 3.8"
+
+  setting {
+    namespace = "aws:elasticbeanstalk:healthreporting:system"
+    name      = "SystemType"
+    value     = "enhanced"
+  }
+
+  setting {
+    namespace = "aws:elasticbeanstalk:managedactions"
+    name      = "ManagedActionsEnabled"
+    value     = "true"
+  }
+
+}

--- a/tests/acceptance/elasticbeanstalk-managed-platform-updates-enabled/test-config.hcl
+++ b/tests/acceptance/elasticbeanstalk-managed-platform-updates-enabled/test-config.hcl
@@ -1,0 +1,38 @@
+name = "elasticbeanstalk-managed-platform-updates-enabled"
+
+disabled = false
+
+case "Elasticbeanstalk managed platform updates enabled in root module" {
+  path = "cases/all-resources-complaint"
+  expectation {
+    result = true
+  }
+}
+
+case "Elasticbeanstalk managed platform updates enabled in nested module" {
+  path = "cases/all-resources-compliant-nested-modules"
+  expectation {
+    result = true
+  }
+}
+
+case "Elasticbeanstalk environment setting undefined" {
+  path = "cases/elasticbeanstalk-environment-setting-undefined"
+  expectation {
+    result = false
+  }
+}
+
+case "Elasticbeanstalk managed actions disabled" {
+  path = "cases/elasticbeanstalk-managed-actions-disabled"
+  expectation {
+    result = false
+  }
+}
+
+case "Elasticbeanstalk platform updates disabled" {
+  path = "cases/elasticbeanstalk-platform-updates-disabled"
+  expectation {
+    result = false
+  }
+}


### PR DESCRIPTION
## Changes proposed in this PR:
- added  elasticbeanstalk platform updates policy
-

## Documentation
- [AWS Standard](https://docs.aws.amazon.com/securityhub/latest/userguide/elasticbeanstalk-controls.html#elasticbeanstalk-2)

## AWS Provider version
<!-- Add information about the provider version against which the policy was tested/developed with. This will later help us when we deal with documentation.Add any nuances that you've observed around provider versions. For example, some attributes will only be present in a certain version of a provider and we need to clearly document that so that users use the expected version.-->

## How I've tested this PR:

## Checklist:
- [x] Tests added