### PR TITLE
added elasticbeanstalk cloudwatch log streaming policy

### DIFF
--- a/docs/policies/elasticbeanstalk-cloudwatch-log-streaming-enabled.md
+++ b/docs/policies/elasticbeanstalk-cloudwatch-log-streaming-enabled.md
@@ -1,0 +1,65 @@
+#  Amazon Elastic Beanstalk environments should have cloudwatch log streaming enabled
+
+| Provider            | Category                    |
+|---------------------|-----------------------------|
+| Amazon Web Services | Application monitoring      |
+
+## Description
+
+This control checks whether an Elastic Beanstalk environment is configured to send logs to CloudWatch Logs. The control fails if an Elastic Beanstalk environment isn't configured to send logs to CloudWatch Logs.
+
+This rule is covered by the [elasticbeanstalk-cloudwatch-log-streaming-enabled](../../policies/elasticbeanstalk-cloudwatch-log-streaming-enabled.sentinel) policy.
+
+## Policy Results (Pass)
+```bash
+trace:
+    Pass - elasticbeanstalk-cloudwatch-log-streaming-enabled.sentinel
+
+    Description:
+    This policy requires that the elasticbeanstalk environment have cloudwatch log
+    streaming enabled
+
+    Print messages:
+
+    → → Overall Result: true
+
+    This result means that all resources have passed the policy check for the policy elasticbeanstalk-cloudwatch-log-streaming-enabled.
+
+    ✓ Found 0 resource violations
+
+    elasticbeanstalk-cloudwatch-log-streaming-enabled.sentinel:48:1 - Rule "main"
+    Value:
+        true
+```
+
+---
+
+## Policy Results (Fail)
+```bash
+trace:
+    Fail - elasticbeanstalk-cloudwatch-log-streaming-enabled.sentinel
+
+    Description:
+    This policy requires that the elasticbeanstalk environment have cloudwatch log
+    streaming enabled
+
+    Print messages:
+
+    → → Overall Result: false
+
+    This result means that not all resources passed the policy check and the protected behavior is not allowed for the policy elasticbeanstalk-cloudwatch-log-streaming-enabled.
+
+    Found 1 resource violations
+
+    → Module name: root
+    ↳ Resource Address: aws_elastic_beanstalk_environment.example
+        | ✗ failed
+        | Elastic Beanstalk environment does not have cloudwatch log streaming enabled. Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/elasticbeanstalk-controls.html#elasticbeanstalk-3 for more details.
+
+
+    elasticbeanstalk-cloudwatch-log-streaming-enabled.sentinel:48:1 - Rule "main"
+    Value:
+        false
+```
+
+---

--- a/policies/elasticbeanstalk-cloudwatch-log-streaming-enabled.sentinel
+++ b/policies/elasticbeanstalk-cloudwatch-log-streaming-enabled.sentinel
@@ -1,0 +1,50 @@
+# This policy requires that the elasticbeanstalk environment have cloudwatch log streaming enabled
+
+# Imports
+
+import "tfplan/v2" as tfplan
+import "tfresources" as tf
+import "report" as report
+import "collection" as collection
+import "collection/maps" as maps
+
+# Constants
+const = {
+	"policy_name":                                "elasticbeanstalk-cloudwatch-log-streaming-enabled",
+	"resource_aws_elastic_beanstalk_environment": "aws_elastic_beanstalk_environment",
+}
+
+# Functions
+get_violations = func(resources) {
+	return collection.reject(resources, func(res) {
+		settings = maps.get(res.values, "setting", [])
+		return collection.find(settings, func(setting) {
+			return setting.namespace is "aws:elasticbeanstalk:cloudwatch:logs" and
+				setting.name is "StreamLogs" and
+				setting.value is "true"
+		}) is defined
+	})
+}
+
+# Variables
+resources = tf.plan(tfplan.planned_values.resources).type(const.resource_aws_elastic_beanstalk_environment).resources
+violations = get_violations(resources)
+
+summary = {
+	"policy_name": const.policy_name,
+	"violations": map violations as _, v {
+		{
+			"address":        v.address,
+			"module_address": v.module_address,
+			"message":        "Elastic Beanstalk environment does not have cloudwatch log streaming enabled. Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/elasticbeanstalk-controls.html#elasticbeanstalk-3 for more details.",
+		}
+	},
+}
+
+# Outputs
+
+print(report.generate_policy_report(summary))
+
+main = rule {
+	violations is empty
+}

--- a/policies/test/elasticbeanstalk-cloudwatch-log-streaming-enabled/failure-cloudwatch-log-streaming-disabled.hcl
+++ b/policies/test/elasticbeanstalk-cloudwatch-log-streaming-enabled/failure-cloudwatch-log-streaming-disabled.hcl
@@ -1,0 +1,21 @@
+mock "tfplan/v2" {
+  module {
+    source = "./mocks/failure-cloudwatch-log-streaming-disabled/mock-tfplan-v2.sentinel"
+  }
+}
+
+import "plugin" "tfresources" {
+  source = "../../../plugins/darwin/arm64/sentinel-plugin-tfresources"
+}
+
+mock "report" {
+  module {
+    source = "../../../modules/mocks/report/report.sentinel"
+  }
+}
+
+test {
+  rules = {
+    main = false
+  }
+}

--- a/policies/test/elasticbeanstalk-cloudwatch-log-streaming-enabled/failure-cloudwatch-log-streaming-not-found.hcl
+++ b/policies/test/elasticbeanstalk-cloudwatch-log-streaming-enabled/failure-cloudwatch-log-streaming-not-found.hcl
@@ -1,0 +1,21 @@
+mock "tfplan/v2" {
+  module {
+    source = "./mocks/failure-cloudwatch-log-streaming-not-found/mock-tfplan-v2.sentinel"
+  }
+}
+
+import "plugin" "tfresources" {
+  source = "../../../plugins/darwin/arm64/sentinel-plugin-tfresources"
+}
+
+mock "report" {
+  module {
+    source = "../../../modules/mocks/report/report.sentinel"
+  }
+}
+
+test {
+  rules = {
+    main = false
+  }
+}

--- a/policies/test/elasticbeanstalk-cloudwatch-log-streaming-enabled/mocks/failure-cloudwatch-log-streaming-disabled/mock-tfplan-v2.sentinel
+++ b/policies/test/elasticbeanstalk-cloudwatch-log-streaming-enabled/mocks/failure-cloudwatch-log-streaming-disabled/mock-tfplan-v2.sentinel
@@ -1,0 +1,74 @@
+terraform_version = "1.7.4"
+
+planned_values = {
+	"outputs": {},
+	"resources": {
+		"aws_elastic_beanstalk_application.example": {
+			"address":        "aws_elastic_beanstalk_application.example",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "example",
+			"provider_name":  "registry.terraform.io/hashicorp/aws",
+			"tainted":        false,
+			"type":           "aws_elastic_beanstalk_application",
+			"values": {
+				"appversion_lifecycle": [],
+				"description":          "An example Elastic Beanstalk application",
+				"name":                 "example-app",
+				"tags":                 null,
+			},
+		},
+		"aws_elastic_beanstalk_environment.example": {
+			"address":        "aws_elastic_beanstalk_environment.example",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "example",
+			"provider_name":  "registry.terraform.io/hashicorp/aws",
+			"tainted":        false,
+			"type":           "aws_elastic_beanstalk_environment",
+			"values": {
+				"application":   "example-app",
+				"description":   null,
+				"name":          "example-env",
+				"poll_interval": null,
+				"setting": [
+					{
+						"name":      "EnvironmentType",
+						"namespace": "aws:elasticbeanstalk:environment",
+						"resource":  "",
+						"value":     "LoadBalanced",
+					},
+					{
+						"name":      "InstanceType",
+						"namespace": "aws:autoscaling:launchconfiguration",
+						"resource":  "",
+						"value":     "t2.micro",
+					},
+					{
+						"name":      "SystemType",
+						"namespace": "aws:elasticbeanstalk:healthreporting:system",
+						"resource":  "",
+						"value":     "basic",
+					},
+					{
+						"name":      "StreamLogs",
+						"namespace": "aws:elasticbeanstalk:cloudwatch:logs",
+						"resource":  "",
+						"value":     "false",
+					},
+				],
+				"solution_stack_name": "64bit Amazon Linux 2 v3.3.10 running Python 3.8",
+				"tags":                null,
+				"template_name":       null,
+				"tier":                "WebServer",
+				"wait_for_ready_timeout": "20m",
+			},
+		},
+	},
+}

--- a/policies/test/elasticbeanstalk-cloudwatch-log-streaming-enabled/mocks/failure-cloudwatch-log-streaming-not-found/mock-tfplan-v2.sentinel
+++ b/policies/test/elasticbeanstalk-cloudwatch-log-streaming-enabled/mocks/failure-cloudwatch-log-streaming-not-found/mock-tfplan-v2.sentinel
@@ -1,0 +1,62 @@
+terraform_version = "1.7.4"
+
+planned_values = {
+	"outputs": {},
+	"resources": {
+		"aws_elastic_beanstalk_application.example": {
+			"address":        "aws_elastic_beanstalk_application.example",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "example",
+			"provider_name":  "registry.terraform.io/hashicorp/aws",
+			"tainted":        false,
+			"type":           "aws_elastic_beanstalk_application",
+			"values": {
+				"appversion_lifecycle": [],
+				"description":          "An example Elastic Beanstalk application",
+				"name":                 "example-app",
+				"tags":                 null,
+			},
+		},
+		"aws_elastic_beanstalk_environment.example": {
+			"address":        "aws_elastic_beanstalk_environment.example",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "example",
+			"provider_name":  "registry.terraform.io/hashicorp/aws",
+			"tainted":        false,
+			"type":           "aws_elastic_beanstalk_environment",
+			"values": {
+				"application":   "example-app",
+				"description":   null,
+				"name":          "example-env",
+				"poll_interval": null,
+				"setting": [
+					{
+						"name":      "EnvironmentType",
+						"namespace": "aws:elasticbeanstalk:environment",
+						"resource":  "",
+						"value":     "LoadBalanced",
+					},
+					{
+						"name":      "InstanceType",
+						"namespace": "aws:autoscaling:launchconfiguration",
+						"resource":  "",
+						"value":     "t2.micro",
+					},
+				],
+				"solution_stack_name": "64bit Amazon Linux 2 v3.3.10 running Python 3.8",
+				"tags":                null,
+				"template_name":       null,
+				"tier":                "WebServer",
+				"wait_for_ready_timeout": "20m",
+			},
+		},
+	},
+}

--- a/policies/test/elasticbeanstalk-cloudwatch-log-streaming-enabled/mocks/success/mock-tfplan-v2.sentinel
+++ b/policies/test/elasticbeanstalk-cloudwatch-log-streaming-enabled/mocks/success/mock-tfplan-v2.sentinel
@@ -1,0 +1,74 @@
+terraform_version = "1.7.4"
+
+planned_values = {
+	"outputs": {},
+	"resources": {
+		"aws_elastic_beanstalk_application.example": {
+			"address":        "aws_elastic_beanstalk_application.example",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "example",
+			"provider_name":  "registry.terraform.io/hashicorp/aws",
+			"tainted":        false,
+			"type":           "aws_elastic_beanstalk_application",
+			"values": {
+				"appversion_lifecycle": [],
+				"description":          "An example Elastic Beanstalk application",
+				"name":                 "example-app",
+				"tags":                 null,
+			},
+		},
+		"aws_elastic_beanstalk_environment.example": {
+			"address":        "aws_elastic_beanstalk_environment.example",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "example",
+			"provider_name":  "registry.terraform.io/hashicorp/aws",
+			"tainted":        false,
+			"type":           "aws_elastic_beanstalk_environment",
+			"values": {
+				"application":   "example-app",
+				"description":   null,
+				"name":          "example-env",
+				"poll_interval": null,
+				"setting": [
+					{
+						"name":      "EnvironmentType",
+						"namespace": "aws:elasticbeanstalk:environment",
+						"resource":  "",
+						"value":     "LoadBalanced",
+					},
+					{
+						"name":      "InstanceType",
+						"namespace": "aws:autoscaling:launchconfiguration",
+						"resource":  "",
+						"value":     "t2.micro",
+					},
+					{
+						"name":      "SystemType",
+						"namespace": "aws:elasticbeanstalk:healthreporting:system",
+						"resource":  "",
+						"value":     "enhanced",
+					},
+					{
+						"name":      "StreamLogs",
+						"namespace": "aws:elasticbeanstalk:cloudwatch:logs",
+						"resource":  "",
+						"value":     "true",
+					},
+				],
+				"solution_stack_name": "64bit Amazon Linux 2 v3.3.10 running Python 3.8",
+				"tags":                null,
+				"template_name":       null,
+				"tier":                "WebServer",
+				"wait_for_ready_timeout": "20m",
+			},
+		},
+	},
+}

--- a/policies/test/elasticbeanstalk-cloudwatch-log-streaming-enabled/success.hcl
+++ b/policies/test/elasticbeanstalk-cloudwatch-log-streaming-enabled/success.hcl
@@ -1,0 +1,21 @@
+mock "tfplan/v2" {
+  module {
+    source = "./mocks/success/mock-tfplan-v2.sentinel"
+  }
+}
+
+import "plugin" "tfresources" {
+  source = "../../../plugins/darwin/arm64/sentinel-plugin-tfresources"
+}
+
+mock "report" {
+  module {
+    source = "../../../modules/mocks/report/report.sentinel"
+  }
+}
+
+test {
+  rules = {
+    main = true
+  }
+}

--- a/sentinel.hcl
+++ b/sentinel.hcl
@@ -192,3 +192,8 @@ policy "elasticbeanstalk-managed-platform-updates-enabled" {
   source = "./policies/elasticbeanstalk-managed-platform-updates-enabled.sentinel"
   enforcement_level = "advisory"
 }
+
+policy "elasticbeanstalk-cloudwatch-log-streaming-enabled" {
+  source = "./policies/elasticbeanstalk-cloudwatch-log-streaming-enabled.sentinel"
+  enforcement_level = "advisory"
+}

--- a/tests/acceptance/elasticbeanstalk-cloudwatch-log-streaming-enabled/cases/all-resources-complaint/backend.tf
+++ b/tests/acceptance/elasticbeanstalk-cloudwatch-log-streaming-enabled/cases/all-resources-complaint/backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  cloud {
+    workspaces {
+      name = "elasticbeanstalk-cloudwatch-log-streaming-enabled"
+    }
+  }
+}

--- a/tests/acceptance/elasticbeanstalk-cloudwatch-log-streaming-enabled/cases/all-resources-complaint/main.tf
+++ b/tests/acceptance/elasticbeanstalk-cloudwatch-log-streaming-enabled/cases/all-resources-complaint/main.tf
@@ -1,0 +1,26 @@
+provider "aws" {
+  region = "us-west-2"
+}
+
+resource "aws_elastic_beanstalk_application" "example" {
+  name        = "example-app"
+  description = "An example Elastic Beanstalk application"
+}
+
+resource "aws_elastic_beanstalk_environment" "example" {
+  name                = "example-env"
+  application         = aws_elastic_beanstalk_application.example.name
+  solution_stack_name = "64bit Amazon Linux 2 v3.3.10 running Python 3.8"
+
+  setting {
+    namespace = "aws:elasticbeanstalk:healthreporting:system"
+    name      = "SystemType"
+    value     = "enhanced"
+  }
+
+  setting {
+    namespace = "aws:elasticbeanstalk:cloudwatch:logs"
+    name      = "StreamLogs"
+    value     = "true"
+  }
+}

--- a/tests/acceptance/elasticbeanstalk-cloudwatch-log-streaming-enabled/cases/all-resources-compliant-nested-modules/backend.tf
+++ b/tests/acceptance/elasticbeanstalk-cloudwatch-log-streaming-enabled/cases/all-resources-compliant-nested-modules/backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  cloud {
+    workspaces {
+      name = "elasticbeanstalk-cloudwatch-log-streaming-enabled"
+    }
+  }
+}

--- a/tests/acceptance/elasticbeanstalk-cloudwatch-log-streaming-enabled/cases/all-resources-compliant-nested-modules/elasticbeanstalk-cloudwatch-log-streaming-enabled/main.tf
+++ b/tests/acceptance/elasticbeanstalk-cloudwatch-log-streaming-enabled/cases/all-resources-compliant-nested-modules/elasticbeanstalk-cloudwatch-log-streaming-enabled/main.tf
@@ -1,0 +1,22 @@
+resource "aws_elastic_beanstalk_application" "example" {
+  name        = "example-app"
+  description = "An example Elastic Beanstalk application"
+}
+
+resource "aws_elastic_beanstalk_environment" "example" {
+  name                = "example-env"
+  application         = aws_elastic_beanstalk_application.example.name
+  solution_stack_name = "64bit Amazon Linux 2 v3.3.10 running Python 3.8"
+
+  setting {
+    namespace = "aws:elasticbeanstalk:healthreporting:system"
+    name      = "SystemType"
+    value     = "enhanced"
+  }
+
+  setting {
+    namespace = "aws:elasticbeanstalk:cloudwatch:logs"
+    name      = "StreamLogs"
+    value     = "true"
+  }
+}

--- a/tests/acceptance/elasticbeanstalk-cloudwatch-log-streaming-enabled/cases/all-resources-compliant-nested-modules/main.tf
+++ b/tests/acceptance/elasticbeanstalk-cloudwatch-log-streaming-enabled/cases/all-resources-compliant-nested-modules/main.tf
@@ -1,0 +1,8 @@
+provider "aws" {
+  region = "us-west-2"
+}
+
+
+module "elasticbeanstalk-cloudwatch-log-streaming" {
+  source = "./elasticbeanstalk-cloudwatch-log-streaming-enabled"
+}

--- a/tests/acceptance/elasticbeanstalk-cloudwatch-log-streaming-enabled/cases/elasticbeanstalk-cloudwatch-log-streaming-disabled/backend.tf
+++ b/tests/acceptance/elasticbeanstalk-cloudwatch-log-streaming-enabled/cases/elasticbeanstalk-cloudwatch-log-streaming-disabled/backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  cloud {
+    workspaces {
+      name = "elasticbeanstalk-cloudwatch-log-streaming-enabled"
+    }
+  }
+}

--- a/tests/acceptance/elasticbeanstalk-cloudwatch-log-streaming-enabled/cases/elasticbeanstalk-cloudwatch-log-streaming-disabled/main.tf
+++ b/tests/acceptance/elasticbeanstalk-cloudwatch-log-streaming-enabled/cases/elasticbeanstalk-cloudwatch-log-streaming-disabled/main.tf
@@ -1,0 +1,27 @@
+provider "aws" {
+  region = "us-west-2"
+}
+
+resource "aws_elastic_beanstalk_application" "example" {
+  name        = "example-app"
+  description = "An example Elastic Beanstalk application"
+}
+
+resource "aws_elastic_beanstalk_environment" "example" {
+  name                = "example-env"
+  application         = aws_elastic_beanstalk_application.example.name
+  solution_stack_name = "64bit Amazon Linux 2 v3.3.10 running Python 3.8"
+
+  setting {
+    namespace = "aws:elasticbeanstalk:healthreporting:system"
+    name      = "SystemType"
+    value     = "basic"
+  }
+
+  setting {
+    namespace = "aws:elasticbeanstalk:cloudwatch:logs"
+    name      = "StreamLogs"
+    value     = "false"
+  }
+
+}

--- a/tests/acceptance/elasticbeanstalk-cloudwatch-log-streaming-enabled/cases/elasticbeanstalk-environment-setting-undefined/backend.tf
+++ b/tests/acceptance/elasticbeanstalk-cloudwatch-log-streaming-enabled/cases/elasticbeanstalk-environment-setting-undefined/backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  cloud {
+    workspaces {
+      name = "elasticbeanstalk-cloudwatch-log-streaming-enabled"
+    }
+  }
+}

--- a/tests/acceptance/elasticbeanstalk-cloudwatch-log-streaming-enabled/cases/elasticbeanstalk-environment-setting-undefined/main.tf
+++ b/tests/acceptance/elasticbeanstalk-cloudwatch-log-streaming-enabled/cases/elasticbeanstalk-environment-setting-undefined/main.tf
@@ -1,0 +1,14 @@
+provider "aws" {
+  region = "us-west-2"
+}
+
+resource "aws_elastic_beanstalk_application" "example" {
+  name        = "example-app"
+  description = "An example Elastic Beanstalk application"
+}
+
+resource "aws_elastic_beanstalk_environment" "example" {
+  name                = "example-env"
+  application         = aws_elastic_beanstalk_application.example.name
+  solution_stack_name = "64bit Amazon Linux 2 v3.3.10 running Python 3.8"
+}

--- a/tests/acceptance/elasticbeanstalk-cloudwatch-log-streaming-enabled/test-config.hcl
+++ b/tests/acceptance/elasticbeanstalk-cloudwatch-log-streaming-enabled/test-config.hcl
@@ -1,0 +1,31 @@
+name = "elasticbeanstalk-cloudwatch-log-streaming-enabled"
+
+disabled = false
+
+case "Elasticbeanstalk cloudwatch log streaming enabled in root module" {
+  path = "cases/all-resources-complaint"
+  expectation {
+    result = true
+  }
+}
+
+case "Elasticbeanstalk cloudwatch log streaming enabled in nested module" {
+  path = "cases/all-resources-compliant-nested-modules"
+  expectation {
+    result = true
+  }
+}
+
+case "Elasticbeanstalk cloudwatch log streaming disabled" {
+  path = "cases/elasticbeanstalk-cloudwatch-log-streaming-disabled"
+  expectation {
+    result = false
+  }
+}
+
+case "elasticbeanstalk environment setting undefined" {
+  path = "cases/elasticbeanstalk-environment-setting-undefined"
+  expectation {
+    result = false
+  }
+}


### PR DESCRIPTION
## Changes proposed in this PR:
- added elasticbeanstalk cloudwatch log streaming policy
-

## Documentation
- [AWS Standard](https://docs.aws.amazon.com/securityhub/latest/userguide/elasticbeanstalk-controls.html#elasticbeanstalk-3)

## AWS Provider version
<!-- Add information about the provider version against which the policy was tested/developed with. This will later help us when we deal with documentation.Add any nuances that you've observed around provider versions. For example, some attributes will only be present in a certain version of a provider and we need to clearly document that so that users use the expected version.-->

## How I've tested this PR:

## Checklist:
- [x] Tests added