### PR TITLE
Add sentinel policy name input to acceptance test workflow

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -1,5 +1,12 @@
 name: Acceptance
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+    inputs:
+      sentinel-policy-name:
+        type: string
+        description: "Name of the sentinel policy that needs to be tested"
+        required: false
+        default: ""
 
 jobs:
   acceptance:
@@ -8,4 +15,5 @@ jobs:
       tfc-organization: ${{ vars.TF_CLOUD_ORGANIZATION }}
       tfc-project: ${{ vars.TF_CLOUD_PROJECT }}
       tfc-hostname: ${{ vars.TF_CLOUD_HOSTNAME }}
+      sentinel-policy-name: ${{ inputs.sentinel-policy-name }}
     secrets: inherit


### PR DESCRIPTION
## Changes proposed in this PR:
- Adds sentinel policy name input to acceptance test workflow

## Documentation
- [AWS Standard](<Link the AWS standard which is supported by this policy>)
- [Policy details](<Link the heading to the policy present in the internal FSBP policies reference document>)

## AWS Provider version
<!-- Add information about the provider version against which the policy was tested/developed with. This will later help us when we deal with documentation.Add any nuances that you've observed around provider versions. For example, some attributes will only be present in a certain version of a provider and we need to clearly document that so that users use the expected version.-->

## How I've tested this PR:

## Checklist:
- [ ] Tests added