### PR TITLE
neptune cluster copy tags to snapshot policy

### DIFF
--- a/docs/policies/neptune-cluster-copy-tags-to-snapshot-enabled.md
+++ b/docs/policies/neptune-cluster-copy-tags-to-snapshot-enabled.md
@@ -1,0 +1,65 @@
+#  Neptune DB clusters should should be configured to copy tags to snapshots
+
+| Provider            | Category                    |
+|---------------------|-----------------------------|
+| Amazon Web Services | Storage                     |
+
+## Description
+
+This control checks if a Neptune DB cluster is configured to copy all tags to snapshots when the snapshots are created. The control fails if a Neptune DB cluster isn't configured to copy tags to snapshots.
+
+This rule is covered by the [neptune-cluster-copy-tags-to-snapshot-enabled](../../policies/neptune-cluster-copy-tags-to-snapshot-enabled.sentinel) policy.
+
+## Policy Results (Pass)
+```bash
+trace:
+    Pass - neptune-cluster-copy-tags-to-snapshot-enabled.sentinel
+
+    Description:
+    This policy requires attribute 'copy_tags_to_snapshot' to be set to true for
+    'aws_neptune_cluster' resources
+
+    Print messages:
+
+    → → Overall Result: true
+
+    This result means that all resources have passed the policy check for the policy neptune-cluster-copy-tags-to-snapshot-enabled.
+
+    ✓ Found 0 resource violations
+
+    neptune-cluster-copy-tags-to-snapshot-enabled.sentinel:46:1 - Rule "main"
+    Value:
+        true
+```
+
+---
+
+## Policy Results (Fail)
+```bash
+trace:
+    Fail - neptune-cluster-copy-tags-to-snapshot-enabled.sentinel
+
+    Description:
+    This policy requires attribute 'copy_tags_to_snapshot' to be set to true for
+    'aws_neptune_cluster' resources
+
+    Print messages:
+
+    → → Overall Result: false
+
+    This result means that not all resources passed the policy check and the protected behavior is not allowed for the policy neptune-cluster-copy-tags-to-snapshot-enabled.
+
+    Found 1 resource violations
+
+    → Module name: root
+    ↳ Resource Address: aws_neptune_cluster.default
+        | ✗ failed
+        | Attribute 'copy_tags_to_snapshot' must have been set to true for 'aws_neptune_cluster' resources.Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/neptune-controls.html#neptune-8 for more details.
+
+
+    neptune-cluster-copy-tags-to-snapshot-enabled.sentinel:46:1 - Rule "main"
+    Value:
+        false
+```
+
+---

--- a/policies/neptune-cluster-copy-tags-to-snapshot-enabled.sentinel
+++ b/policies/neptune-cluster-copy-tags-to-snapshot-enabled.sentinel
@@ -1,0 +1,48 @@
+# This policy requires attribute 'copy_tags_to_snapshot' to be set to true for 'aws_neptune_cluster' resources
+
+# Imports
+
+import "tfplan/v2" as tfplan
+import "tfresources" as tf
+import "report" as report
+import "collection" as collection
+import "collection/maps" as maps
+
+# Constants
+const = {
+	"policy_name":                  "neptune-cluster-copy-tags-to-snapshot-enabled",
+	"resource_aws_neptune_cluster": "aws_neptune_cluster",
+}
+
+# Functions
+get_violations = func(resources) {
+	return collection.reject(resources, func(res) {
+		return maps.get(res, "values.copy_tags_to_snapshot", false) is true
+	})
+}
+
+# Variables
+
+aws_neptune_clusters = tf.plan(tfplan.planned_values.resources).type(const.resource_aws_neptune_cluster).resources
+violations = get_violations(aws_neptune_clusters)
+
+summary = {
+	"policy_name": const.policy_name,
+	"violations": map violations as _, v {
+		{
+			"address":        v.address,
+			"module_address": v.module_address,
+			"message":        "Attribute 'copy_tags_to_snapshot' must have been set to true for 'aws_neptune_cluster' resources.Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/neptune-controls.html#neptune-8 for more details.",
+		}
+	},
+}
+
+# Outputs
+
+print(report.generate_policy_report(summary))
+
+# Rules
+
+main = rule {
+	violations is empty
+}

--- a/policies/test/neptune-cluster-copy-tags-to-snapshot-enabled/mocks/policy-failure-copy-tags-to-snapshot-disabled/mock-tfplan-v2.sentinel
+++ b/policies/test/neptune-cluster-copy-tags-to-snapshot-enabled/mocks/policy-failure-copy-tags-to-snapshot-disabled/mock-tfplan-v2.sentinel
@@ -1,0 +1,43 @@
+terraform_version = "1.7.4"
+
+planned_values = {
+	"outputs": {},
+	"resources": {
+		"aws_neptune_cluster.default": {
+			"address":        "aws_neptune_cluster.default",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "default",
+			"provider_name":  "registry.terraform.io/hashicorp/aws",
+			"tainted":        false,
+			"type":           "aws_neptune_cluster",
+			"values": {
+				"apply_immediately":              true,
+				"backup_retention_period":        5,
+				"cluster_identifier":             "neptune-cluster-demo",
+				"copy_tags_to_snapshot":          false,
+				"deletion_protection":            false,
+				"enable_cloudwatch_logs_exports": null,
+				"engine":                                "neptune",
+				"final_snapshot_identifier":             null,
+				"global_cluster_identifier":             null,
+				"iam_database_authentication_enabled":   false,
+				"iam_roles":                             null,
+				"neptune_cluster_parameter_group_name":  "default.neptune1",
+				"neptune_instance_parameter_group_name": null,
+				"port": 8182,
+				"preferred_backup_window":             "07:00-09:00",
+				"replication_source_identifier":       null,
+				"serverless_v2_scaling_configuration": [],
+				"skip_final_snapshot":                 true,
+				"snapshot_identifier":                 null,
+				"storage_encrypted":                   false,
+				"tags":                                null,
+				"timeouts":                            null,
+			},
+		},
+	},
+}

--- a/policies/test/neptune-cluster-copy-tags-to-snapshot-enabled/mocks/policy-failure-copy-tags-to-snapshot-not-defined/mock-tfplan-v2.sentinel
+++ b/policies/test/neptune-cluster-copy-tags-to-snapshot-enabled/mocks/policy-failure-copy-tags-to-snapshot-not-defined/mock-tfplan-v2.sentinel
@@ -1,0 +1,43 @@
+terraform_version = "1.7.4"
+
+planned_values = {
+	"outputs": {},
+	"resources": {
+		"aws_neptune_cluster.default": {
+			"address":        "aws_neptune_cluster.default",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "default",
+			"provider_name":  "registry.terraform.io/hashicorp/aws",
+			"tainted":        false,
+			"type":           "aws_neptune_cluster",
+			"values": {
+				"apply_immediately":              true,
+				"backup_retention_period":        5,
+				"cluster_identifier":             "neptune-cluster-demo",
+				"copy_tags_to_snapshot":          null,
+				"deletion_protection":            null,
+				"enable_cloudwatch_logs_exports": null,
+				"engine":                                "neptune",
+				"final_snapshot_identifier":             null,
+				"global_cluster_identifier":             null,
+				"iam_database_authentication_enabled":   null,
+				"iam_roles":                             null,
+				"neptune_cluster_parameter_group_name":  "default.neptune1",
+				"neptune_instance_parameter_group_name": null,
+				"port": 8182,
+				"preferred_backup_window":             "07:00-09:00",
+				"replication_source_identifier":       null,
+				"serverless_v2_scaling_configuration": [],
+				"skip_final_snapshot":                 true,
+				"snapshot_identifier":                 null,
+				"storage_encrypted":                   false,
+				"tags":                                null,
+				"timeouts":                            null,
+			},
+		},
+	},
+}

--- a/policies/test/neptune-cluster-copy-tags-to-snapshot-enabled/mocks/policy-success/mock-tfplan-v2.sentinel
+++ b/policies/test/neptune-cluster-copy-tags-to-snapshot-enabled/mocks/policy-success/mock-tfplan-v2.sentinel
@@ -1,0 +1,43 @@
+terraform_version = "1.7.4"
+
+planned_values = {
+	"outputs": {},
+	"resources": {
+		"aws_neptune_cluster.default": {
+			"address":        "aws_neptune_cluster.default",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "default",
+			"provider_name":  "registry.terraform.io/hashicorp/aws",
+			"tainted":        false,
+			"type":           "aws_neptune_cluster",
+			"values": {
+				"apply_immediately":              true,
+				"backup_retention_period":        5,
+				"cluster_identifier":             "neptune-cluster-demo",
+				"copy_tags_to_snapshot":          true,
+				"deletion_protection":            true,
+				"enable_cloudwatch_logs_exports": null,
+				"engine":                                "neptune",
+				"final_snapshot_identifier":             null,
+				"global_cluster_identifier":             null,
+				"iam_database_authentication_enabled":   true,
+				"iam_roles":                             null,
+				"neptune_cluster_parameter_group_name":  "default.neptune1",
+				"neptune_instance_parameter_group_name": null,
+				"port": 8182,
+				"preferred_backup_window":             "07:00-09:00",
+				"replication_source_identifier":       null,
+				"serverless_v2_scaling_configuration": [],
+				"skip_final_snapshot":                 true,
+				"snapshot_identifier":                 null,
+				"storage_encrypted":                   true,
+				"tags":                                null,
+				"timeouts":                            null,
+			},
+		},
+	},
+}

--- a/policies/test/neptune-cluster-copy-tags-to-snapshot-enabled/policy-failure-copy-tags-to-snapshot-disabled.hcl
+++ b/policies/test/neptune-cluster-copy-tags-to-snapshot-enabled/policy-failure-copy-tags-to-snapshot-disabled.hcl
@@ -1,0 +1,23 @@
+mock "tfplan/v2" {
+	module {
+		source = "./mocks/policy-failure-copy-tags-to-snapshot-disabled/mock-tfplan-v2.sentinel"
+	}
+}
+
+
+
+import "plugin" "tfresources" {
+	source = "../../../plugins/darwin/arm64/sentinel-plugin-tfresources"
+}
+
+mock "report" {
+	module {
+		source = "../../../modules/mocks/report/report.sentinel"
+	}
+}
+
+test {
+	rules = {
+		main = false
+	}
+}

--- a/policies/test/neptune-cluster-copy-tags-to-snapshot-enabled/policy-failure-copy-tags-to-snapshot-not-defined.hcl
+++ b/policies/test/neptune-cluster-copy-tags-to-snapshot-enabled/policy-failure-copy-tags-to-snapshot-not-defined.hcl
@@ -1,0 +1,21 @@
+mock "tfplan/v2" {
+	module {
+		source = "./mocks/policy-failure-copy-tags-to-snapshot-not-defined/mock-tfplan-v2.sentinel"
+	}
+}
+
+import "plugin" "tfresources" {
+	source = "../../../plugins/darwin/arm64/sentinel-plugin-tfresources"
+}
+
+mock "report" {
+	module {
+		source = "../../../modules/mocks/report/report.sentinel"
+	}
+}
+
+test {
+	rules = {
+		main = false
+	}
+}

--- a/policies/test/neptune-cluster-copy-tags-to-snapshot-enabled/success.hcl
+++ b/policies/test/neptune-cluster-copy-tags-to-snapshot-enabled/success.hcl
@@ -1,0 +1,21 @@
+mock "tfplan/v2" {
+	module {
+		source = "./mocks/policy-success/mock-tfplan-v2.sentinel"
+	}
+}
+
+import "plugin" "tfresources" {
+	source = "../../../plugins/darwin/arm64/sentinel-plugin-tfresources"
+}
+
+mock "report" {
+	module {
+		source = "../../../modules/mocks/report/report.sentinel"
+	}
+}
+
+test {
+	rules = {
+		main = true
+	}
+}

--- a/sentinel.hcl
+++ b/sentinel.hcl
@@ -363,3 +363,8 @@ policy "neptune-cluster-db-auth-enabled" {
  source = "./policies/neptune-cluster-db-auth-enabled.sentinel"
  enforcement_level = "advisory"
 }
+
+policy "neptune-cluster-copy-tags-to-snapshot-enabled" {
+ source = "./policies/neptune-cluster-copy-tags-to-snapshot-enabled.sentinel"
+ enforcement_level = "advisory"
+}

--- a/tests/acceptance/neptune-cluster-copy-tags-to-snapshot-enabled/cases/copy-tags-to-snapshot-disabled/backend.tf
+++ b/tests/acceptance/neptune-cluster-copy-tags-to-snapshot-enabled/cases/copy-tags-to-snapshot-disabled/backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  cloud {
+    workspaces {
+      name = "neptune-cluster-copy-tags-to-snapshot-enabled"
+    }
+  }
+}

--- a/tests/acceptance/neptune-cluster-copy-tags-to-snapshot-enabled/cases/copy-tags-to-snapshot-disabled/main.tf
+++ b/tests/acceptance/neptune-cluster-copy-tags-to-snapshot-enabled/cases/copy-tags-to-snapshot-disabled/main.tf
@@ -1,0 +1,16 @@
+provider "aws" {
+  region = "us-west-2"
+}
+
+resource "aws_neptune_cluster" "default" {
+  cluster_identifier                  = "neptune-cluster-demo"
+  engine                              = "neptune"
+  backup_retention_period             = 5
+  preferred_backup_window             = "07:00-09:00"
+  skip_final_snapshot                 = true
+  iam_database_authentication_enabled = false
+  apply_immediately                   = true
+  storage_encrypted                   = false
+  deletion_protection                 = false
+  copy_tags_to_snapshot               = false
+}

--- a/tests/acceptance/neptune-cluster-copy-tags-to-snapshot-enabled/cases/copy-tags-to-snapshot-enabled-nested-module/backend.tf
+++ b/tests/acceptance/neptune-cluster-copy-tags-to-snapshot-enabled/cases/copy-tags-to-snapshot-enabled-nested-module/backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  cloud {
+    workspaces {
+      name = "neptune-cluster-copy-tags-to-snapshot-enabled"
+    }
+  }
+}

--- a/tests/acceptance/neptune-cluster-copy-tags-to-snapshot-enabled/cases/copy-tags-to-snapshot-enabled-nested-module/main.tf
+++ b/tests/acceptance/neptune-cluster-copy-tags-to-snapshot-enabled/cases/copy-tags-to-snapshot-enabled-nested-module/main.tf
@@ -1,0 +1,7 @@
+provider "aws" {
+  region = "us-west-2"
+}
+
+module "neptune-cluster" {
+  source = "./neptune-cluster"
+}

--- a/tests/acceptance/neptune-cluster-copy-tags-to-snapshot-enabled/cases/copy-tags-to-snapshot-enabled-nested-module/neptune-cluster/main.tf
+++ b/tests/acceptance/neptune-cluster-copy-tags-to-snapshot-enabled/cases/copy-tags-to-snapshot-enabled-nested-module/neptune-cluster/main.tf
@@ -1,0 +1,16 @@
+provider "aws" {
+  region = "us-west-2"
+}
+
+resource "aws_neptune_cluster" "default" {
+  cluster_identifier                  = "neptune-cluster-demo"
+  engine                              = "neptune"
+  backup_retention_period             = 5
+  preferred_backup_window             = "07:00-09:00"
+  skip_final_snapshot                 = true
+  iam_database_authentication_enabled = true
+  apply_immediately                   = true
+  storage_encrypted                   = true
+  deletion_protection                 = true
+  copy_tags_to_snapshot               = true
+}

--- a/tests/acceptance/neptune-cluster-copy-tags-to-snapshot-enabled/cases/copy-tags-to-snapshot-enabled/backend.tf
+++ b/tests/acceptance/neptune-cluster-copy-tags-to-snapshot-enabled/cases/copy-tags-to-snapshot-enabled/backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  cloud {
+    workspaces {
+      name = "neptune-cluster-copy-tags-to-snapshot-enabled"
+    }
+  }
+}

--- a/tests/acceptance/neptune-cluster-copy-tags-to-snapshot-enabled/cases/copy-tags-to-snapshot-enabled/main.tf
+++ b/tests/acceptance/neptune-cluster-copy-tags-to-snapshot-enabled/cases/copy-tags-to-snapshot-enabled/main.tf
@@ -1,0 +1,16 @@
+provider "aws" {
+  region = "us-west-2"
+}
+
+resource "aws_neptune_cluster" "default" {
+  cluster_identifier                  = "neptune-cluster-demo"
+  engine                              = "neptune"
+  backup_retention_period             = 5
+  preferred_backup_window             = "07:00-09:00"
+  skip_final_snapshot                 = true
+  iam_database_authentication_enabled = true
+  apply_immediately                   = true
+  storage_encrypted                   = true
+  deletion_protection                 = true
+  copy_tags_to_snapshot               = true
+}

--- a/tests/acceptance/neptune-cluster-copy-tags-to-snapshot-enabled/cases/copy-tags-to-snapshot-not-defined/backend.tf
+++ b/tests/acceptance/neptune-cluster-copy-tags-to-snapshot-enabled/cases/copy-tags-to-snapshot-not-defined/backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  cloud {
+    workspaces {
+      name = "neptune-cluster-copy-tags-to-snapshot-enabled"
+    }
+  }
+}

--- a/tests/acceptance/neptune-cluster-copy-tags-to-snapshot-enabled/cases/copy-tags-to-snapshot-not-defined/main.tf
+++ b/tests/acceptance/neptune-cluster-copy-tags-to-snapshot-enabled/cases/copy-tags-to-snapshot-not-defined/main.tf
@@ -1,0 +1,12 @@
+provider "aws" {
+  region = "us-west-2"
+}
+
+resource "aws_neptune_cluster" "default" {
+  cluster_identifier      = "neptune-cluster-demo"
+  engine                  = "neptune"
+  backup_retention_period = 5
+  preferred_backup_window = "07:00-09:00"
+  skip_final_snapshot     = true
+  apply_immediately       = true
+}

--- a/tests/acceptance/neptune-cluster-copy-tags-to-snapshot-enabled/test-config.hcl
+++ b/tests/acceptance/neptune-cluster-copy-tags-to-snapshot-enabled/test-config.hcl
@@ -1,0 +1,31 @@
+name = "neptune-cluster-copy-tags-to-snapshot-enabled"
+
+disabled = false
+
+case "Copy tags to snapshot enabled" {
+    path = "./cases/copy-tags-to-snapshot-enabled"
+    expectation {
+        result = true
+    }
+}
+
+case "Copy tags to snapshot disabled" {
+    path = "./cases/copy-tags-to-snapshot-disabled"
+    expectation {
+        result = false
+    }
+}
+
+case "Copy tags to snapshot not defined" {
+    path = "./cases/copy-tags-to-snapshot-not-defined"
+    expectation {
+        result = false
+    }
+}
+
+case "Copy tags to snapshot enabled nested module" {
+    path = "./cases/copy-tags-to-snapshot-enabled-nested-module"
+    expectation {
+        result = true
+    }
+}


### PR DESCRIPTION
## Changes proposed in this PR:
- neptune cluster copy tags to snapshot policy
-

## Documentation
- [AWS Standard](<https://docs.aws.amazon.com/securityhub/latest/userguide/neptune-controls.html#neptune-8>)
- [Policy details](<Link the heading to the policy present in the internal FSBP policies reference document>)

## AWS Provider version
<!-- Add information about the provider version against which the policy was tested/developed with. This will later help us when we deal with documentation.Add any nuances that you've observed around provider versions. For example, some attributes will only be present in a certain version of a provider and we need to clearly document that so that users use the expected version.-->

## How I've tested this PR:

## Checklist:
- [x] Tests added