### PR TITLE
Created the policy Amazon SageMaker notebook instances should not have direct internet access

### DIFF
--- a/docs/policies/sagemaker-notebook-no-direct-internet-access.md
+++ b/docs/policies/sagemaker-notebook-no-direct-internet-access.md
@@ -1,0 +1,71 @@
+# AWS Sagemaker Notebook instance should have the direct_internet_access set to "Disabled"
+
+| Provider            | Category         |
+| ------------------- | ---------------- |
+| Amazon Web Services | Machine Learning |
+
+## Description
+
+This control checks whether direct internet access is disabled for an SageMaker notebook instance. The control fails if the DirectInternetAccess field is enabled for the notebook instance.
+
+If you configure your SageMaker instance without a VPC, then by default direct internet access is enabled on your instance. You should configure your instance with a VPC and change the default setting to Disable—Access the internet through a VPC. To train or host models from a notebook, you need internet access.
+
+This rule is covered by the [sagemaker-notebook-no-direct-internet-access](../../policies/sagemaker-notebook-no-direct-internet-access.sentinel) policy.
+
+## Policy Results (Pass)
+
+```bash
+trace:
+      Pass - sagemaker-notebook-no-direct-internet-access.sentinel
+
+      Description:
+        This policy checks if resources of type 'aws_sagemaker_notebook_instance' have
+        the 'direct_internet_access'
+        attribute set to "Disabled"
+
+      Print messages:
+
+      → → Overall Result: true
+
+      This result means that all resources have passed the policy check for the policy sagemaker-notebook-no-direct-internet-access.
+
+      ✓ Found 0 resource violations
+
+      sagemaker-notebook-no-direct-internet-access.sentinel:47:1 - Rule "main"
+        Value:
+          true
+```
+
+---
+
+## Policy Results (Fail)
+
+```bash
+trace:
+      Fail - sagemaker-notebook-no-direct-internet-access.sentinel
+
+      Description:
+        This policy checks if resources of type 'aws_sagemaker_notebook_instance' have
+        the 'direct_internet_access'
+        attribute set to "Disabled"
+
+      Print messages:
+
+      → → Overall Result: false
+
+      This result means that not all resources passed the policy check and the protected behavior is not allowed for the policy sagemaker-notebook-no-direct-internet-access.
+
+      Found 1 resource violations
+
+      → Module name: root
+        ↳ Resource Address: aws_sagemaker_notebook_instance.ni
+          | ✗ failed
+          | Attribute 'direct_internet_access' should be Disabled for AWS Sagemaker Notebook Instance. Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/sagemaker-controls.html#sagemaker-1 for more details.
+
+
+      sagemaker-notebook-no-direct-internet-access.sentinel:47:1 - Rule "main"
+        Value:
+          false
+```
+
+---

--- a/policies/sagemaker-notebook-no-direct-internet-access.sentinel
+++ b/policies/sagemaker-notebook-no-direct-internet-access.sentinel
@@ -1,0 +1,51 @@
+# This policy checks if resources of type 'aws_sagemaker_notebook_instance' have the 'direct_internet_access'
+# attribute set to "Disabled"
+
+import "tfplan/v2" as tfplan
+import "tfresources" as tf
+import "report" as report
+import "collection" as collection
+import "collection/maps" as maps
+import "json"
+
+# Constants
+const = {
+	"policy_name": "sagemaker-notebook-no-direct-internet-access",
+	"message":     "Attribute 'direct_internet_access' should be Disabled for AWS Sagemaker Notebook Instance. Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/sagemaker-controls.html#sagemaker-1 for more details.",
+	"resource_aws_sagemaker_notebook_instance": "aws_sagemaker_notebook_instance",
+	"direct_internet_access_value_enabled":     "Enabled",
+	"direct_internet_access_value_disabled":    "Disabled",
+}
+
+# Functions
+
+get_violations = func(resources) {
+	return collection.reject(resources, func(res) {
+		return maps.get(res, "values.direct_internet_access", const.direct_internet_access_value_enabled) is const.direct_internet_access_value_disabled
+	})
+}
+
+# Variables
+
+sagemaker_notebooks = tf.plan(tfplan.planned_values.resources).type(const.resource_aws_sagemaker_notebook_instance).resources
+violations = get_violations(sagemaker_notebooks)
+
+summary = {
+	"policy_name": const.policy_name,
+	"violations": map violations as _, v {
+		{
+			"address":        v.address,
+			"module_address": v.module_address,
+			"message":        const.message,
+		}
+	},
+}
+
+# Outputs
+print(report.generate_policy_report(summary))
+
+# Rules
+
+main = rule {
+	violations is empty
+}

--- a/policies/test/sagemaker-notebook-no-direct-internet-access/failure-sagemaker-notebook-with-direct-internet-access-enabled.hcl
+++ b/policies/test/sagemaker-notebook-no-direct-internet-access/failure-sagemaker-notebook-with-direct-internet-access-enabled.hcl
@@ -1,0 +1,21 @@
+mock "tfplan/v2" {
+  module {
+    source = "./mocks/policy-failure-sagemaker-notebook-with-direct-internet-access-enabled/mock-tfplan-v2.sentinel"
+  }
+}
+
+import "plugin" "tfresources" {
+  source = "../../../plugins/darwin/arm64/sentinel-plugin-tfresources"
+}
+
+mock "report" {
+  module {
+    source = "../../../modules/mocks/report/report.sentinel"
+  }
+}
+
+test {
+  rules = {
+    main = false
+  }
+}

--- a/policies/test/sagemaker-notebook-no-direct-internet-access/failure-sagemaker-notebook-with-no-direct-internet-access-attribute.hcl
+++ b/policies/test/sagemaker-notebook-no-direct-internet-access/failure-sagemaker-notebook-with-no-direct-internet-access-attribute.hcl
@@ -1,0 +1,21 @@
+mock "tfplan/v2" {
+  module {
+    source = "./mocks/policy-failure-sagemaker-notebook-with-no-direct-internet-access-attribute/mock-tfplan-v2.sentinel"
+  }
+}
+
+import "plugin" "tfresources" {
+  source = "../../../plugins/darwin/arm64/sentinel-plugin-tfresources"
+}
+
+mock "report" {
+  module {
+    source = "../../../modules/mocks/report/report.sentinel"
+  }
+}
+
+test {
+  rules = {
+    main = false
+  }
+}

--- a/policies/test/sagemaker-notebook-no-direct-internet-access/mocks/policy-failure-sagemaker-notebook-with-direct-internet-access-enabled/mock-tfplan-v2.sentinel
+++ b/policies/test/sagemaker-notebook-no-direct-internet-access/mocks/policy-failure-sagemaker-notebook-with-direct-internet-access-enabled/mock-tfplan-v2.sentinel
@@ -1,0 +1,62 @@
+planned_values = {
+	"outputs": {},
+	"resources": {
+		"aws_iam_role.test_role": {
+			"address":        "aws_iam_role.test_role",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "test_role",
+			"provider_name":  "registry.terraform.io/hashicorp/aws",
+			"tainted":        false,
+			"type":           "aws_iam_role",
+			"values": {
+				"assume_role_policy":    "{\"Statement\":[{\"Action\":\"sts:AssumeRole\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"ec2.amazonaws.com\"}}],\"Version\":\"2012-10-17\"}",
+				"description":           null,
+				"force_detach_policies": false,
+				"max_session_duration":  3600,
+				"name":                  "test_role",
+				"path":                  "/",
+				"permissions_boundary":  null,
+				"tags": {
+					"tag-key": "tag-value",
+				},
+				"tags_all": {
+					"tag-key": "tag-value",
+				},
+			},
+		},
+		"aws_sagemaker_notebook_instance.ni": {
+			"address":        "aws_sagemaker_notebook_instance.ni",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "ni",
+			"provider_name":  "registry.terraform.io/hashicorp/aws",
+			"tainted":        false,
+			"type":           "aws_sagemaker_notebook_instance",
+			"values": {
+				"additional_code_repositories": null,
+				"default_code_repository":      null,
+				"direct_internet_access":       "Enabled",
+				"instance_type":                "ml.t2.medium",
+				"kms_key_id":                   null,
+				"lifecycle_config_name":        null,
+				"name":                         "my-notebook-instance",
+				"root_access":                  "Enabled",
+				"subnet_id":                    null,
+				"tags": {
+					"Name": "foo",
+				},
+				"tags_all": {
+					"Name": "foo",
+				},
+				"volume_size": 5,
+			},
+		},
+	},
+}

--- a/policies/test/sagemaker-notebook-no-direct-internet-access/mocks/policy-failure-sagemaker-notebook-with-no-direct-internet-access-attribute/mock-tfplan-v2.sentinel
+++ b/policies/test/sagemaker-notebook-no-direct-internet-access/mocks/policy-failure-sagemaker-notebook-with-no-direct-internet-access-attribute/mock-tfplan-v2.sentinel
@@ -1,0 +1,62 @@
+planned_values = {
+	"outputs": {},
+	"resources": {
+		"aws_iam_role.test_role": {
+			"address":        "aws_iam_role.test_role",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "test_role",
+			"provider_name":  "registry.terraform.io/hashicorp/aws",
+			"tainted":        false,
+			"type":           "aws_iam_role",
+			"values": {
+				"assume_role_policy":    "{\"Statement\":[{\"Action\":\"sts:AssumeRole\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"ec2.amazonaws.com\"}}],\"Version\":\"2012-10-17\"}",
+				"description":           null,
+				"force_detach_policies": false,
+				"max_session_duration":  3600,
+				"name":                  "test_role",
+				"path":                  "/",
+				"permissions_boundary":  null,
+				"tags": {
+					"tag-key": "tag-value",
+				},
+				"tags_all": {
+					"tag-key": "tag-value",
+				},
+			},
+		},
+		"aws_sagemaker_notebook_instance.ni": {
+			"address":        "aws_sagemaker_notebook_instance.ni",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "ni",
+			"provider_name":  "registry.terraform.io/hashicorp/aws",
+			"tainted":        false,
+			"type":           "aws_sagemaker_notebook_instance",
+			"values": {
+				"additional_code_repositories": null,
+				"default_code_repository":      null,
+				"direct_internet_access":       "Enabled",
+				"instance_type":                "ml.t2.medium",
+				"kms_key_id":                   null,
+				"lifecycle_config_name":        null,
+				"name":                         "my-notebook-instance",
+				"root_access":                  "Enabled",
+				"subnet_id":                    null,
+				"tags": {
+					"Name": "foo",
+				},
+				"tags_all": {
+					"Name": "foo",
+				},
+				"volume_size": 5,
+			},
+		},
+	},
+}

--- a/policies/test/sagemaker-notebook-no-direct-internet-access/mocks/policy-success-sagemaker-notebook-with-direct-internet-access-disabled/mock-tfplan-v2.sentinel
+++ b/policies/test/sagemaker-notebook-no-direct-internet-access/mocks/policy-success-sagemaker-notebook-with-direct-internet-access-disabled/mock-tfplan-v2.sentinel
@@ -1,0 +1,62 @@
+planned_values = {
+	"outputs": {},
+	"resources": {
+		"aws_iam_role.test_role": {
+			"address":        "aws_iam_role.test_role",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "test_role",
+			"provider_name":  "registry.terraform.io/hashicorp/aws",
+			"tainted":        false,
+			"type":           "aws_iam_role",
+			"values": {
+				"assume_role_policy":    "{\"Statement\":[{\"Action\":\"sts:AssumeRole\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"ec2.amazonaws.com\"}}],\"Version\":\"2012-10-17\"}",
+				"description":           null,
+				"force_detach_policies": false,
+				"max_session_duration":  3600,
+				"name":                  "test_role",
+				"path":                  "/",
+				"permissions_boundary":  null,
+				"tags": {
+					"tag-key": "tag-value",
+				},
+				"tags_all": {
+					"tag-key": "tag-value",
+				},
+			},
+		},
+		"aws_sagemaker_notebook_instance.ni": {
+			"address":        "aws_sagemaker_notebook_instance.ni",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "ni",
+			"provider_name":  "registry.terraform.io/hashicorp/aws",
+			"tainted":        false,
+			"type":           "aws_sagemaker_notebook_instance",
+			"values": {
+				"additional_code_repositories": null,
+				"default_code_repository":      null,
+				"direct_internet_access":       "Disabled",
+				"instance_type":                "ml.t2.medium",
+				"kms_key_id":                   null,
+				"lifecycle_config_name":        null,
+				"name":                         "my-notebook-instance",
+				"root_access":                  "Enabled",
+				"subnet_id":                    null,
+				"tags": {
+					"Name": "foo",
+				},
+				"tags_all": {
+					"Name": "foo",
+				},
+				"volume_size": 5,
+			},
+		},
+	},
+}

--- a/policies/test/sagemaker-notebook-no-direct-internet-access/success-sagemaker-notebook-with-direct-internet-access-disabled.hcl
+++ b/policies/test/sagemaker-notebook-no-direct-internet-access/success-sagemaker-notebook-with-direct-internet-access-disabled.hcl
@@ -1,0 +1,21 @@
+mock "tfplan/v2" {
+  module {
+    source = "./mocks/policy-success-sagemaker-notebook-with-direct-internet-access-disabled/mock-tfplan-v2.sentinel"
+  }
+}
+
+import "plugin" "tfresources" {
+  source = "../../../plugins/darwin/arm64/sentinel-plugin-tfresources"
+}
+
+mock "report" {
+  module {
+    source = "../../../modules/mocks/report/report.sentinel"
+  }
+}
+
+test {
+  rules = {
+    main = true
+  }
+}

--- a/sentinel.hcl
+++ b/sentinel.hcl
@@ -397,6 +397,11 @@ policy "neptune-cluster-snapshot-encryption-at-rest-enabled" {
  enforcement_level = "advisory"
 }
 
+policy "sagemaker-notebook-no-direct-internet-access" {
+  source = "./policies/sagemaker-notebook-no-direct-internet-access.sentinel"
+  enforcement_level = "advisory"
+}
+
 policy "sagemaker-notebook-ensure-subnet-id-for-instance" {
   source = "./policies/sagemaker-notebook-ensure-subnet-id-for-instance.sentinel"
   enforcement_level = "advisory"

--- a/tests/acceptance/sagamaker-notebook-no-direct-internet-access/cases/sagemaker-notebook-instance-with-direct-internet-access-disabled-nested/backend.tf
+++ b/tests/acceptance/sagamaker-notebook-no-direct-internet-access/cases/sagemaker-notebook-instance-with-direct-internet-access-disabled-nested/backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  cloud {
+    workspaces {
+      name = "sagemaker-notebook-no-direct-internet-access"
+    }
+  }
+}

--- a/tests/acceptance/sagamaker-notebook-no-direct-internet-access/cases/sagemaker-notebook-instance-with-direct-internet-access-disabled-nested/main.tf
+++ b/tests/acceptance/sagamaker-notebook-no-direct-internet-access/cases/sagemaker-notebook-instance-with-direct-internet-access-disabled-nested/main.tf
@@ -1,0 +1,17 @@
+terraform {
+  required_providers {
+    aws = {
+      version = " ~> 3.0"
+      source  = "registry.terraform.io/hashicorp/aws"
+    }
+  }
+}
+
+provider "aws" {
+  region = "us-west-2"
+}
+
+module "sagemaker-notebook-instance" {
+  source                          = "./sagemaker-notebook-instance"
+  direct_internet_access_variable = "Disabled"
+}

--- a/tests/acceptance/sagamaker-notebook-no-direct-internet-access/cases/sagemaker-notebook-instance-with-direct-internet-access-disabled-nested/sagemaker-notebook-instance/main.tf
+++ b/tests/acceptance/sagamaker-notebook-no-direct-internet-access/cases/sagemaker-notebook-instance-with-direct-internet-access-disabled-nested/sagemaker-notebook-instance/main.tf
@@ -1,0 +1,29 @@
+resource "aws_sagemaker_notebook_instance" "simple_notebook_instance" {
+  name                   = "my-notebook-instance"
+  role_arn               = aws_iam_role.test_role.arn
+  direct_internet_access = var.direct_internet_access_variable
+  instance_type          = "ml.t2.medium"
+  tags = {
+    Name = "foo"
+  }
+}
+
+resource "aws_iam_role" "test_role" {
+  name = "test_role"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "ec2.amazonaws.com"
+        }
+      },
+    ]
+  })
+
+  tags = {
+    tag-key = "tag-value"
+  }
+}

--- a/tests/acceptance/sagamaker-notebook-no-direct-internet-access/cases/sagemaker-notebook-instance-with-direct-internet-access-disabled-nested/sagemaker-notebook-instance/variables.tf
+++ b/tests/acceptance/sagamaker-notebook-no-direct-internet-access/cases/sagemaker-notebook-instance-with-direct-internet-access-disabled-nested/sagemaker-notebook-instance/variables.tf
@@ -1,0 +1,3 @@
+variable "direct_internet_access_variable" {
+  type = string
+}

--- a/tests/acceptance/sagamaker-notebook-no-direct-internet-access/cases/sagemaker-notebook-instance-with-direct-internet-access-disabled/backend.tf
+++ b/tests/acceptance/sagamaker-notebook-no-direct-internet-access/cases/sagemaker-notebook-instance-with-direct-internet-access-disabled/backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  cloud {
+    workspaces {
+      name = "sagemaker-notebook-no-direct-internet-access"
+    }
+  }
+}

--- a/tests/acceptance/sagamaker-notebook-no-direct-internet-access/cases/sagemaker-notebook-instance-with-direct-internet-access-disabled/main.tf
+++ b/tests/acceptance/sagamaker-notebook-no-direct-internet-access/cases/sagemaker-notebook-instance-with-direct-internet-access-disabled/main.tf
@@ -1,0 +1,42 @@
+terraform {
+  required_providers {
+    aws = {
+      version = " ~> 3.0"
+      source  = "registry.terraform.io/hashicorp/aws"
+    }
+  }
+}
+
+provider "aws" {
+  region = "us-west-2"
+}
+
+resource "aws_sagemaker_notebook_instance" "simple_notebook_instance" {
+  name                   = "my-notebook-instance"
+  role_arn               = aws_iam_role.test_role.arn
+  direct_internet_access = "Disabled"
+  instance_type          = "ml.t2.medium"
+  tags = {
+    Name = "foo"
+  }
+}
+
+resource "aws_iam_role" "test_role" {
+  name = "test_role"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "ec2.amazonaws.com"
+        }
+      },
+    ]
+  })
+
+  tags = {
+    tag-key = "tag-value"
+  }
+}

--- a/tests/acceptance/sagamaker-notebook-no-direct-internet-access/cases/sagemaker-notebook-instance-with-direct-internet-access-enabled/backend.tf
+++ b/tests/acceptance/sagamaker-notebook-no-direct-internet-access/cases/sagemaker-notebook-instance-with-direct-internet-access-enabled/backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  cloud {
+    workspaces {
+      name = "sagemaker-notebook-no-direct-internet-access"
+    }
+  }
+}

--- a/tests/acceptance/sagamaker-notebook-no-direct-internet-access/cases/sagemaker-notebook-instance-with-direct-internet-access-enabled/main.tf
+++ b/tests/acceptance/sagamaker-notebook-no-direct-internet-access/cases/sagemaker-notebook-instance-with-direct-internet-access-enabled/main.tf
@@ -1,0 +1,42 @@
+terraform {
+  required_providers {
+    aws = {
+      version = " ~> 3.0"
+      source  = "registry.terraform.io/hashicorp/aws"
+    }
+  }
+}
+
+provider "aws" {
+  region = "us-west-2"
+}
+
+resource "aws_sagemaker_notebook_instance" "simple_notebook_instance" {
+  name                   = "my-notebook-instance"
+  role_arn               = aws_iam_role.test_role.arn
+  direct_internet_access = "Enabled"
+  instance_type          = "ml.t2.medium"
+  tags = {
+    Name = "foo"
+  }
+}
+
+resource "aws_iam_role" "test_role" {
+  name = "test_role"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "ec2.amazonaws.com"
+        }
+      },
+    ]
+  })
+
+  tags = {
+    tag-key = "tag-value"
+  }
+}

--- a/tests/acceptance/sagamaker-notebook-no-direct-internet-access/cases/sagemaker-notebook-instance-with-no-direct-internet-access-attribute/backend.tf
+++ b/tests/acceptance/sagamaker-notebook-no-direct-internet-access/cases/sagemaker-notebook-instance-with-no-direct-internet-access-attribute/backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  cloud {
+    workspaces {
+      name = "sagemaker-notebook-no-direct-internet-access"
+    }
+  }
+}

--- a/tests/acceptance/sagamaker-notebook-no-direct-internet-access/cases/sagemaker-notebook-instance-with-no-direct-internet-access-attribute/main.tf
+++ b/tests/acceptance/sagamaker-notebook-no-direct-internet-access/cases/sagemaker-notebook-instance-with-no-direct-internet-access-attribute/main.tf
@@ -1,0 +1,41 @@
+terraform {
+  required_providers {
+    aws = {
+      version = " ~> 3.0"
+      source  = "registry.terraform.io/hashicorp/aws"
+    }
+  }
+}
+
+provider "aws" {
+  region = "us-west-2"
+}
+
+resource "aws_sagemaker_notebook_instance" "simple_notebook_instance" {
+  name          = "my-notebook-instance"
+  role_arn      = aws_iam_role.test_role.arn
+  instance_type = "ml.t2.medium"
+  tags = {
+    Name = "foo"
+  }
+}
+
+resource "aws_iam_role" "test_role" {
+  name = "test_role"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "ec2.amazonaws.com"
+        }
+      },
+    ]
+  })
+
+  tags = {
+    tag-key = "tag-value"
+  }
+}

--- a/tests/acceptance/sagamaker-notebook-no-direct-internet-access/test-config.hcl
+++ b/tests/acceptance/sagamaker-notebook-no-direct-internet-access/test-config.hcl
@@ -1,0 +1,31 @@
+name = "sagemaker-notebook-no-direct-internet-access"
+
+disabled = false
+
+case "Sagemaker Notebook Instance with Direct Internet Access Disabled" {
+    path = "./cases/sagemaker-notebook-instance-with-direct-internet-access-disabled"
+    expectation {
+        result = true
+    }
+}
+
+case "Sagemaker Notebook Instance with Direct Internet Access Disabled Nested" {
+    path = "./cases/sagemaker-notebook-instance-with-direct-internet-access-disabled-nested"
+    expectation {
+        result = true
+    }
+}
+
+case "Sagemaker Notebook Instance with Direct Internet Access Enabled" {
+    path = "./cases/sagemaker-notebook-instance-with-direct-internet-access-enabled"
+    expectation {
+        result = false
+    }
+}
+
+case "Sagemaker Notebook Instance with No Direct Internet Access Attribute" {
+    path = "./cases/sagemaker-notebook-instance-with-no-direct-internet-access-attribute"
+    expectation {
+        result = false
+    }
+}


### PR DESCRIPTION
## Changes proposed in this PR:
-  Created the policy Amazon SageMaker notebook instances should not have direct internet access
-

## Documentation
- [AWS Standard](https://docs.aws.amazon.com/securityhub/latest/userguide/sagemaker-controls.html#sagemaker-1)
- 

## AWS Provider version

## How I've tested this PR:

## Checklist:
- [x] Tests added