### PR TITLE
Added policy for API Gateway SSl Certificates Configure

### DIFF
--- a/docs/policies/api-gateway-rest-configure-ssl-certificates.md
+++ b/docs/policies/api-gateway-rest-configure-ssl-certificates.md
@@ -1,0 +1,67 @@
+# API Gateway REST API stages should be configured to use SSL certificates for backend authentication
+
+| Provider            | Category        |
+|---------------------|-----------------|
+| Amazon Web Services | Data Protection |
+
+## Description
+
+This control checks whether Amazon API Gateway REST API stages have SSL certificates configured. Backend systems use these certificates to authenticate that incoming requests are from API Gateway.
+
+API Gateway REST API stages should be configured with SSL certificates to allow backend systems to authenticate that requests originate from API Gateway.
+
+This rule is covered by the [api-gateway-rest-configure-ssl-certificates](../../policies/api-gateway-rest-configure-ssl-certificates.sentinel) policy.
+
+## Policy Results (Pass)
+```bash
+trace:
+      Pass - api-gateway-rest-configure-ssl-certificates.sentinel
+
+      Description:
+        This policy checks whether 'aws_api_gateway_stage' have SSL certificates
+        configured.
+
+      Print messages:
+
+      → → Overall Result: true
+
+      This result means that all resources have passed the policy check for the policy api-gateway-rest-configure-ssl-certificates.
+
+      ✓ Found 0 resource violations
+
+      api-gateway-rest-configure-ssl-certificates.sentinel:47:1 - Rule "main"
+        Value:
+          true
+```
+
+---
+
+## Policy Results (Fail)
+```bash
+trace:
+      Fail - api-gateway-rest-configure-ssl-certificates.sentinel
+
+      Description:
+        This policy checks whether 'aws_api_gateway_stage' have SSL certificates
+        configured.
+
+      Print messages:
+
+      → → Overall Result: false
+
+      This result means that not all resources passed the policy check and the protected behavior is not allowed for the policy api-gateway-rest-configure-ssl-certificates.
+
+      Found 1 resource violations
+
+      → Module name: root
+        ↳ Resource Address: aws_api_gateway_stage.example
+          | ✗ failed
+          | SSL certificates should be configured for resource 'aws_api_gateway_stage' for backend authentication. Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/apigateway-controls.html#apigateway-2 for more details.
+
+
+      api-gateway-rest-configure-ssl-certificates.sentinel:47:1 - Rule "main"
+        Value:
+          false
+```
+
+---

--- a/policies/api-gateway-rest-configure-ssl-certificates.sentinel
+++ b/policies/api-gateway-rest-configure-ssl-certificates.sentinel
@@ -1,0 +1,49 @@
+# This policy checks whether 'aws_api_gateway_stage' have SSL certificates configured.
+
+import "tfplan/v2" as tfplan
+import "tfresources" as tf
+import "report" as report
+import "collection" as collection
+import "collection/maps" as maps
+
+# Constants
+const = {
+	"policy_name":                    "api-gateway-rest-configure-ssl-certificates",
+	"resource_aws_api_gateway_stage": "aws_api_gateway_stage",
+	"message":                        "SSL certificates should be configured for resource 'aws_api_gateway_stage' for backend authentication. Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/apigateway-controls.html#apigateway-2 for more details.",
+}
+
+# Functions
+
+get_violations = func(resources) {
+	return collection.reject(resources, func(res) {
+		client_certificate_id = maps.get(res, "values.client_certificate_id", null)
+		return client_certificate_id is not null
+	})
+}
+
+# Variables
+
+aws_api_gateway_stage = tf.plan(tfplan.planned_values.resources).type(const.resource_aws_api_gateway_stage).resources
+violations = get_violations(aws_api_gateway_stage)
+
+summary = {
+	"policy_name": const.policy_name,
+	"violations": map violations as _, v {
+		{
+			"address":        v.address,
+			"module_address": v.module_address,
+			"message":        const.message,
+		}
+	},
+}
+
+# Outputs
+
+print(report.generate_policy_report(summary))
+
+# Rules
+
+main = rule {
+	violations is empty
+}

--- a/policies/test/api-gateway-rest-configure-ssl-certificates/failure-client-certificate-id-is-null.hcl
+++ b/policies/test/api-gateway-rest-configure-ssl-certificates/failure-client-certificate-id-is-null.hcl
@@ -1,0 +1,23 @@
+mock "tfplan/v2" {
+	module {
+		source = "./mocks/policy-failure-client-certificate-id-is-null/mock-tfplan-v2.sentinel"
+	}
+}
+
+
+
+import "plugin" "tfresources" {
+	source = "../../../plugins/darwin/arm64/sentinel-plugin-tfresources"
+}
+
+mock "report" {
+	module {
+		source = "../../../modules/mocks/report/report.sentinel"
+	}
+}
+
+test {
+	rules = {
+		main = false
+	}
+}

--- a/policies/test/api-gateway-rest-configure-ssl-certificates/mocks/policy-failure-client-certificate-id-is-null/mock-tfplan-v2.sentinel
+++ b/policies/test/api-gateway-rest-configure-ssl-certificates/mocks/policy-failure-client-certificate-id-is-null/mock-tfplan-v2.sentinel
@@ -1,0 +1,680 @@
+terraform_version = "1.9.5"
+
+planned_values = {
+	"outputs": {},
+	"resources": {
+		"aws_api_gateway_deployment.example": {
+			"address":        "aws_api_gateway_deployment.example",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "example",
+			"provider_name":  "registry.terraform.io/hashicorp/aws",
+			"tainted":        false,
+			"type":           "aws_api_gateway_deployment",
+			"values": {
+				"canary_settings":   [],
+				"description":       null,
+				"stage_description": null,
+				"stage_name":        null,
+				"triggers": {
+					"redeployment": "145be397ea51cabb14595b0f0ace006017953f0a",
+				},
+				"variables": null,
+			},
+		},
+		"aws_api_gateway_method_settings.example": {
+			"address":        "aws_api_gateway_method_settings.example",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "example",
+			"provider_name":  "registry.terraform.io/hashicorp/aws",
+			"tainted":        false,
+			"type":           "aws_api_gateway_method_settings",
+			"values": {
+				"method_path": "*/*",
+				"settings": [
+					{
+						"logging_level":          "INFO",
+						"metrics_enabled":        true,
+						"throttling_burst_limit": -1,
+						"throttling_rate_limit":  -1,
+					},
+				],
+				"stage_name": "example",
+			},
+		},
+		"aws_api_gateway_rest_api.example": {
+			"address":        "aws_api_gateway_rest_api.example",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "example",
+			"provider_name":  "registry.terraform.io/hashicorp/aws",
+			"tainted":        false,
+			"type":           "aws_api_gateway_rest_api",
+			"values": {
+				"body":              "{\"info\":{\"title\":\"example\",\"version\":\"1.0\"},\"openapi\":\"3.0.1\",\"paths\":{\"/path1\":{\"get\":{\"x-amazon-apigateway-integration\":{\"httpMethod\":\"GET\",\"payloadFormatVersion\":\"1.0\",\"type\":\"HTTP_PROXY\",\"uri\":\"https://ip-ranges.amazonaws.com/ip-ranges.json\"}}}}}",
+				"fail_on_warnings":  null,
+				"name":              "example",
+				"parameters":        null,
+				"put_rest_api_mode": null,
+				"tags":              null,
+			},
+		},
+		"aws_api_gateway_stage.example": {
+			"address":        "aws_api_gateway_stage.example",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "example",
+			"provider_name":  "registry.terraform.io/hashicorp/aws",
+			"tainted":        false,
+			"type":           "aws_api_gateway_stage",
+			"values": {
+				"access_log_settings":   [],
+				"cache_cluster_enabled": null,
+				"cache_cluster_size":    null,
+				"canary_settings":       [],
+				"client_certificate_id": null,
+				"description":           null,
+				"documentation_version": null,
+				"stage_name":            "example",
+				"tags":                  null,
+				"variables":             null,
+				"xray_tracing_enabled":  null,
+			},
+		},
+	},
+}
+
+variables = {}
+
+resource_changes = {
+	"aws_api_gateway_deployment.example": {
+		"address": "aws_api_gateway_deployment.example",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"canary_settings":   [],
+				"description":       null,
+				"stage_description": null,
+				"stage_name":        null,
+				"triggers": {
+					"redeployment": "145be397ea51cabb14595b0f0ace006017953f0a",
+				},
+				"variables": null,
+			},
+			"after_unknown": {
+				"canary_settings": [],
+				"created_date":    true,
+				"execution_arn":   true,
+				"id":              true,
+				"invoke_url":      true,
+				"rest_api_id":     true,
+				"triggers":        {},
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "example",
+		"provider_name":  "registry.terraform.io/hashicorp/aws",
+		"type":           "aws_api_gateway_deployment",
+	},
+	"aws_api_gateway_method_settings.example": {
+		"address": "aws_api_gateway_method_settings.example",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"method_path": "*/*",
+				"settings": [
+					{
+						"logging_level":          "INFO",
+						"metrics_enabled":        true,
+						"throttling_burst_limit": -1,
+						"throttling_rate_limit":  -1,
+					},
+				],
+				"stage_name": "example",
+			},
+			"after_unknown": {
+				"id":          true,
+				"rest_api_id": true,
+				"settings": [
+					{
+						"cache_data_encrypted":                       true,
+						"cache_ttl_in_seconds":                       true,
+						"caching_enabled":                            true,
+						"data_trace_enabled":                         true,
+						"require_authorization_for_cache_control":    true,
+						"unauthorized_cache_control_header_strategy": true,
+					},
+				],
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "example",
+		"provider_name":  "registry.terraform.io/hashicorp/aws",
+		"type":           "aws_api_gateway_method_settings",
+	},
+	"aws_api_gateway_rest_api.example": {
+		"address": "aws_api_gateway_rest_api.example",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"body":              "{\"info\":{\"title\":\"example\",\"version\":\"1.0\"},\"openapi\":\"3.0.1\",\"paths\":{\"/path1\":{\"get\":{\"x-amazon-apigateway-integration\":{\"httpMethod\":\"GET\",\"payloadFormatVersion\":\"1.0\",\"type\":\"HTTP_PROXY\",\"uri\":\"https://ip-ranges.amazonaws.com/ip-ranges.json\"}}}}}",
+				"fail_on_warnings":  null,
+				"name":              "example",
+				"parameters":        null,
+				"put_rest_api_mode": null,
+				"tags":              null,
+			},
+			"after_unknown": {
+				"api_key_source":               true,
+				"arn":                          true,
+				"binary_media_types":           true,
+				"created_date":                 true,
+				"description":                  true,
+				"disable_execute_api_endpoint": true,
+				"endpoint_configuration":       true,
+				"execution_arn":                true,
+				"id":                           true,
+				"minimum_compression_size": true,
+				"policy":                   true,
+				"root_resource_id":         true,
+				"tags_all":                 true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "example",
+		"provider_name":  "registry.terraform.io/hashicorp/aws",
+		"type":           "aws_api_gateway_rest_api",
+	},
+	"aws_api_gateway_stage.example": {
+		"address": "aws_api_gateway_stage.example",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"access_log_settings":   [],
+				"cache_cluster_enabled": null,
+				"cache_cluster_size":    null,
+				"canary_settings":       [],
+				"client_certificate_id": null,
+				"description":           null,
+				"documentation_version": null,
+				"stage_name":            "example",
+				"tags":                  null,
+				"variables":             null,
+				"xray_tracing_enabled":  null,
+			},
+			"after_unknown": {
+				"access_log_settings": [],
+				"arn":             true,
+				"canary_settings": [],
+				"deployment_id":   true,
+				"execution_arn":   true,
+				"id":              true,
+				"invoke_url":      true,
+				"rest_api_id":     true,
+				"tags_all":        true,
+				"web_acl_arn":     true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "example",
+		"provider_name":  "registry.terraform.io/hashicorp/aws",
+		"type":           "aws_api_gateway_stage",
+	},
+}
+
+resource_drift = {}
+
+output_changes = {}
+
+raw = {
+	"complete": true,
+	"configuration": {
+		"provider_config": {
+			"aws": {
+				"expressions": {
+					"region": {
+						"constant_value": "us-west-2",
+					},
+				},
+				"full_name": "registry.terraform.io/hashicorp/aws",
+				"name":      "aws",
+			},
+		},
+		"root_module": {
+			"resources": [
+				{
+					"address": "aws_api_gateway_deployment.example",
+					"expressions": {
+						"rest_api_id": {
+							"references": [
+								"aws_api_gateway_rest_api.example.id",
+								"aws_api_gateway_rest_api.example",
+							],
+						},
+						"triggers": {
+							"references": [
+								"aws_api_gateway_rest_api.example.body",
+								"aws_api_gateway_rest_api.example",
+							],
+						},
+					},
+					"mode":                "managed",
+					"name":                "example",
+					"provider_config_key": "aws",
+					"schema_version":      0,
+					"type":                "aws_api_gateway_deployment",
+				},
+				{
+					"address": "aws_api_gateway_method_settings.example",
+					"expressions": {
+						"method_path": {
+							"constant_value": "*/*",
+						},
+						"rest_api_id": {
+							"references": [
+								"aws_api_gateway_rest_api.example.id",
+								"aws_api_gateway_rest_api.example",
+							],
+						},
+						"settings": [
+							{
+								"logging_level": {
+									"constant_value": "INFO",
+								},
+								"metrics_enabled": {
+									"constant_value": true,
+								},
+							},
+						],
+						"stage_name": {
+							"references": [
+								"aws_api_gateway_stage.example.stage_name",
+								"aws_api_gateway_stage.example",
+							],
+						},
+					},
+					"mode":                "managed",
+					"name":                "example",
+					"provider_config_key": "aws",
+					"schema_version":      0,
+					"type":                "aws_api_gateway_method_settings",
+				},
+				{
+					"address": "aws_api_gateway_rest_api.example",
+					"expressions": {
+						"body": {},
+						"name": {
+							"constant_value": "example",
+						},
+					},
+					"mode":                "managed",
+					"name":                "example",
+					"provider_config_key": "aws",
+					"schema_version":      0,
+					"type":                "aws_api_gateway_rest_api",
+				},
+				{
+					"address": "aws_api_gateway_stage.example",
+					"expressions": {
+						"deployment_id": {
+							"references": [
+								"aws_api_gateway_deployment.example.id",
+								"aws_api_gateway_deployment.example",
+							],
+						},
+						"rest_api_id": {
+							"references": [
+								"aws_api_gateway_rest_api.example.id",
+								"aws_api_gateway_rest_api.example",
+							],
+						},
+						"stage_name": {
+							"constant_value": "example",
+						},
+					},
+					"mode":                "managed",
+					"name":                "example",
+					"provider_config_key": "aws",
+					"schema_version":      0,
+					"type":                "aws_api_gateway_stage",
+				},
+			],
+		},
+	},
+	"format_version": "1.2",
+	"planned_values": {
+		"root_module": {
+			"resources": [
+				{
+					"address":        "aws_api_gateway_deployment.example",
+					"mode":           "managed",
+					"name":           "example",
+					"provider_name":  "registry.terraform.io/hashicorp/aws",
+					"schema_version": 0,
+					"sensitive_values": {
+						"canary_settings": [],
+						"triggers":        {},
+					},
+					"type": "aws_api_gateway_deployment",
+					"values": {
+						"canary_settings":   [],
+						"description":       null,
+						"stage_description": null,
+						"stage_name":        null,
+						"triggers": {
+							"redeployment": "145be397ea51cabb14595b0f0ace006017953f0a",
+						},
+						"variables": null,
+					},
+				},
+				{
+					"address":        "aws_api_gateway_method_settings.example",
+					"mode":           "managed",
+					"name":           "example",
+					"provider_name":  "registry.terraform.io/hashicorp/aws",
+					"schema_version": 0,
+					"sensitive_values": {
+						"settings": [
+							{},
+						],
+					},
+					"type": "aws_api_gateway_method_settings",
+					"values": {
+						"method_path": "*/*",
+						"settings": [
+							{
+								"logging_level":          "INFO",
+								"metrics_enabled":        true,
+								"throttling_burst_limit": -1,
+								"throttling_rate_limit":  -1,
+							},
+						],
+						"stage_name": "example",
+					},
+				},
+				{
+					"address":        "aws_api_gateway_rest_api.example",
+					"mode":           "managed",
+					"name":           "example",
+					"provider_name":  "registry.terraform.io/hashicorp/aws",
+					"schema_version": 0,
+					"sensitive_values": {
+						"binary_media_types":     [],
+						"endpoint_configuration": [],
+						"tags_all":               {},
+					},
+					"type": "aws_api_gateway_rest_api",
+					"values": {
+						"body":              "{\"info\":{\"title\":\"example\",\"version\":\"1.0\"},\"openapi\":\"3.0.1\",\"paths\":{\"/path1\":{\"get\":{\"x-amazon-apigateway-integration\":{\"httpMethod\":\"GET\",\"payloadFormatVersion\":\"1.0\",\"type\":\"HTTP_PROXY\",\"uri\":\"https://ip-ranges.amazonaws.com/ip-ranges.json\"}}}}}",
+						"fail_on_warnings":  null,
+						"name":              "example",
+						"parameters":        null,
+						"put_rest_api_mode": null,
+						"tags":              null,
+					},
+				},
+				{
+					"address":        "aws_api_gateway_stage.example",
+					"mode":           "managed",
+					"name":           "example",
+					"provider_name":  "registry.terraform.io/hashicorp/aws",
+					"schema_version": 0,
+					"sensitive_values": {
+						"access_log_settings": [],
+						"canary_settings":     [],
+						"tags_all":            {},
+					},
+					"type": "aws_api_gateway_stage",
+					"values": {
+						"access_log_settings":   [],
+						"cache_cluster_enabled": null,
+						"cache_cluster_size":    null,
+						"canary_settings":       [],
+						"client_certificate_id": null,
+						"description":           null,
+						"documentation_version": null,
+						"stage_name":            "example",
+						"tags":                  null,
+						"variables":             null,
+						"xray_tracing_enabled":  null,
+					},
+				},
+			],
+		},
+	},
+	"relevant_attributes": [
+		{
+			"attribute": [
+				"stage_name",
+			],
+			"resource": "aws_api_gateway_stage.example",
+		},
+		{
+			"attribute": [
+				"id",
+			],
+			"resource": "aws_api_gateway_rest_api.example",
+		},
+		{
+			"attribute": [
+				"body",
+			],
+			"resource": "aws_api_gateway_rest_api.example",
+		},
+		{
+			"attribute": [
+				"id",
+			],
+			"resource": "aws_api_gateway_deployment.example",
+		},
+	],
+	"resource_changes": [
+		{
+			"address": "aws_api_gateway_deployment.example",
+			"change": {
+				"actions": [
+					"create",
+				],
+				"after": {
+					"canary_settings":   [],
+					"description":       null,
+					"stage_description": null,
+					"stage_name":        null,
+					"triggers": {
+						"redeployment": "145be397ea51cabb14595b0f0ace006017953f0a",
+					},
+					"variables": null,
+				},
+				"after_sensitive": {
+					"canary_settings": [],
+					"triggers":        {},
+				},
+				"after_unknown": {
+					"canary_settings": [],
+					"created_date":    true,
+					"execution_arn":   true,
+					"id":              true,
+					"invoke_url":      true,
+					"rest_api_id":     true,
+					"triggers":        {},
+				},
+				"before":           null,
+				"before_sensitive": false,
+			},
+			"mode":          "managed",
+			"name":          "example",
+			"provider_name": "registry.terraform.io/hashicorp/aws",
+			"type":          "aws_api_gateway_deployment",
+		},
+		{
+			"address": "aws_api_gateway_method_settings.example",
+			"change": {
+				"actions": [
+					"create",
+				],
+				"after": {
+					"method_path": "*/*",
+					"settings": [
+						{
+							"logging_level":          "INFO",
+							"metrics_enabled":        true,
+							"throttling_burst_limit": -1,
+							"throttling_rate_limit":  -1,
+						},
+					],
+					"stage_name": "example",
+				},
+				"after_sensitive": {
+					"settings": [
+						{},
+					],
+				},
+				"after_unknown": {
+					"id":          true,
+					"rest_api_id": true,
+					"settings": [
+						{
+							"cache_data_encrypted":                       true,
+							"cache_ttl_in_seconds":                       true,
+							"caching_enabled":                            true,
+							"data_trace_enabled":                         true,
+							"require_authorization_for_cache_control":    true,
+							"unauthorized_cache_control_header_strategy": true,
+						},
+					],
+				},
+				"before":           null,
+				"before_sensitive": false,
+			},
+			"mode":          "managed",
+			"name":          "example",
+			"provider_name": "registry.terraform.io/hashicorp/aws",
+			"type":          "aws_api_gateway_method_settings",
+		},
+		{
+			"address": "aws_api_gateway_rest_api.example",
+			"change": {
+				"actions": [
+					"create",
+				],
+				"after": {
+					"body":              "{\"info\":{\"title\":\"example\",\"version\":\"1.0\"},\"openapi\":\"3.0.1\",\"paths\":{\"/path1\":{\"get\":{\"x-amazon-apigateway-integration\":{\"httpMethod\":\"GET\",\"payloadFormatVersion\":\"1.0\",\"type\":\"HTTP_PROXY\",\"uri\":\"https://ip-ranges.amazonaws.com/ip-ranges.json\"}}}}}",
+					"fail_on_warnings":  null,
+					"name":              "example",
+					"parameters":        null,
+					"put_rest_api_mode": null,
+					"tags":              null,
+				},
+				"after_sensitive": {
+					"binary_media_types":     [],
+					"endpoint_configuration": [],
+					"tags_all":               {},
+				},
+				"after_unknown": {
+					"api_key_source":               true,
+					"arn":                          true,
+					"binary_media_types":           true,
+					"created_date":                 true,
+					"description":                  true,
+					"disable_execute_api_endpoint": true,
+					"endpoint_configuration":       true,
+					"execution_arn":                true,
+					"id":                           true,
+					"minimum_compression_size": true,
+					"policy":                   true,
+					"root_resource_id":         true,
+					"tags_all":                 true,
+				},
+				"before":           null,
+				"before_sensitive": false,
+			},
+			"mode":          "managed",
+			"name":          "example",
+			"provider_name": "registry.terraform.io/hashicorp/aws",
+			"type":          "aws_api_gateway_rest_api",
+		},
+		{
+			"address": "aws_api_gateway_stage.example",
+			"change": {
+				"actions": [
+					"create",
+				],
+				"after": {
+					"access_log_settings":   [],
+					"cache_cluster_enabled": null,
+					"cache_cluster_size":    null,
+					"canary_settings":       [],
+					"client_certificate_id": null,
+					"description":           null,
+					"documentation_version": null,
+					"stage_name":            "example",
+					"tags":                  null,
+					"variables":             null,
+					"xray_tracing_enabled":  null,
+				},
+				"after_sensitive": {
+					"access_log_settings": [],
+					"canary_settings":     [],
+					"tags_all":            {},
+				},
+				"after_unknown": {
+					"access_log_settings": [],
+					"arn":             true,
+					"canary_settings": [],
+					"deployment_id":   true,
+					"execution_arn":   true,
+					"id":              true,
+					"invoke_url":      true,
+					"rest_api_id":     true,
+					"tags_all":        true,
+					"web_acl_arn":     true,
+				},
+				"before":           null,
+				"before_sensitive": false,
+			},
+			"mode":          "managed",
+			"name":          "example",
+			"provider_name": "registry.terraform.io/hashicorp/aws",
+			"type":          "aws_api_gateway_stage",
+		},
+	],
+	"terraform_version": "1.9.5",
+	"timestamp":         "2024-10-08T20:58:29Z",
+}

--- a/policies/test/api-gateway-rest-configure-ssl-certificates/mocks/policy-success-client-certificate-id-is-not-null/mock-tfplan-v2.sentinel
+++ b/policies/test/api-gateway-rest-configure-ssl-certificates/mocks/policy-success-client-certificate-id-is-not-null/mock-tfplan-v2.sentinel
@@ -1,0 +1,683 @@
+terraform_version = "1.9.5"
+
+planned_values = {
+	"outputs": {},
+	"resources": {
+		"aws_api_gateway_deployment.example": {
+			"address":        "aws_api_gateway_deployment.example",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "example",
+			"provider_name":  "registry.terraform.io/hashicorp/aws",
+			"tainted":        false,
+			"type":           "aws_api_gateway_deployment",
+			"values": {
+				"canary_settings":   [],
+				"description":       null,
+				"stage_description": null,
+				"stage_name":        null,
+				"triggers": {
+					"redeployment": "145be397ea51cabb14595b0f0ace006017953f0a",
+				},
+				"variables": null,
+			},
+		},
+		"aws_api_gateway_method_settings.example": {
+			"address":        "aws_api_gateway_method_settings.example",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "example",
+			"provider_name":  "registry.terraform.io/hashicorp/aws",
+			"tainted":        false,
+			"type":           "aws_api_gateway_method_settings",
+			"values": {
+				"method_path": "*/*",
+				"settings": [
+					{
+						"logging_level":          "INFO",
+						"metrics_enabled":        true,
+						"throttling_burst_limit": -1,
+						"throttling_rate_limit":  -1,
+					},
+				],
+				"stage_name": "example",
+			},
+		},
+		"aws_api_gateway_rest_api.example": {
+			"address":        "aws_api_gateway_rest_api.example",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "example",
+			"provider_name":  "registry.terraform.io/hashicorp/aws",
+			"tainted":        false,
+			"type":           "aws_api_gateway_rest_api",
+			"values": {
+				"body":              "{\"info\":{\"title\":\"example\",\"version\":\"1.0\"},\"openapi\":\"3.0.1\",\"paths\":{\"/path1\":{\"get\":{\"x-amazon-apigateway-integration\":{\"httpMethod\":\"GET\",\"payloadFormatVersion\":\"1.0\",\"type\":\"HTTP_PROXY\",\"uri\":\"https://ip-ranges.amazonaws.com/ip-ranges.json\"}}}}}",
+				"fail_on_warnings":  null,
+				"name":              "example",
+				"parameters":        null,
+				"put_rest_api_mode": null,
+				"tags":              null,
+			},
+		},
+		"aws_api_gateway_stage.example": {
+			"address":        "aws_api_gateway_stage.example",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "example",
+			"provider_name":  "registry.terraform.io/hashicorp/aws",
+			"tainted":        false,
+			"type":           "aws_api_gateway_stage",
+			"values": {
+				"access_log_settings":   [],
+				"cache_cluster_enabled": null,
+				"cache_cluster_size":    null,
+				"canary_settings":       [],
+				"client_certificate_id": "abc123",
+				"description":           null,
+				"documentation_version": null,
+				"stage_name":            "example",
+				"tags":                  null,
+				"variables":             null,
+				"xray_tracing_enabled":  null,
+			},
+		},
+	},
+}
+
+variables = {}
+
+resource_changes = {
+	"aws_api_gateway_deployment.example": {
+		"address": "aws_api_gateway_deployment.example",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"canary_settings":   [],
+				"description":       null,
+				"stage_description": null,
+				"stage_name":        null,
+				"triggers": {
+					"redeployment": "145be397ea51cabb14595b0f0ace006017953f0a",
+				},
+				"variables": null,
+			},
+			"after_unknown": {
+				"canary_settings": [],
+				"created_date":    true,
+				"execution_arn":   true,
+				"id":              true,
+				"invoke_url":      true,
+				"rest_api_id":     true,
+				"triggers":        {},
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "example",
+		"provider_name":  "registry.terraform.io/hashicorp/aws",
+		"type":           "aws_api_gateway_deployment",
+	},
+	"aws_api_gateway_method_settings.example": {
+		"address": "aws_api_gateway_method_settings.example",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"method_path": "*/*",
+				"settings": [
+					{
+						"logging_level":          "INFO",
+						"metrics_enabled":        true,
+						"throttling_burst_limit": -1,
+						"throttling_rate_limit":  -1,
+					},
+				],
+				"stage_name": "example",
+			},
+			"after_unknown": {
+				"id":          true,
+				"rest_api_id": true,
+				"settings": [
+					{
+						"cache_data_encrypted":                       true,
+						"cache_ttl_in_seconds":                       true,
+						"caching_enabled":                            true,
+						"data_trace_enabled":                         true,
+						"require_authorization_for_cache_control":    true,
+						"unauthorized_cache_control_header_strategy": true,
+					},
+				],
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "example",
+		"provider_name":  "registry.terraform.io/hashicorp/aws",
+		"type":           "aws_api_gateway_method_settings",
+	},
+	"aws_api_gateway_rest_api.example": {
+		"address": "aws_api_gateway_rest_api.example",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"body":              "{\"info\":{\"title\":\"example\",\"version\":\"1.0\"},\"openapi\":\"3.0.1\",\"paths\":{\"/path1\":{\"get\":{\"x-amazon-apigateway-integration\":{\"httpMethod\":\"GET\",\"payloadFormatVersion\":\"1.0\",\"type\":\"HTTP_PROXY\",\"uri\":\"https://ip-ranges.amazonaws.com/ip-ranges.json\"}}}}}",
+				"fail_on_warnings":  null,
+				"name":              "example",
+				"parameters":        null,
+				"put_rest_api_mode": null,
+				"tags":              null,
+			},
+			"after_unknown": {
+				"api_key_source":               true,
+				"arn":                          true,
+				"binary_media_types":           true,
+				"created_date":                 true,
+				"description":                  true,
+				"disable_execute_api_endpoint": true,
+				"endpoint_configuration":       true,
+				"execution_arn":                true,
+				"id":                           true,
+				"minimum_compression_size": true,
+				"policy":                   true,
+				"root_resource_id":         true,
+				"tags_all":                 true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "example",
+		"provider_name":  "registry.terraform.io/hashicorp/aws",
+		"type":           "aws_api_gateway_rest_api",
+	},
+	"aws_api_gateway_stage.example": {
+		"address": "aws_api_gateway_stage.example",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"access_log_settings":   [],
+				"cache_cluster_enabled": null,
+				"cache_cluster_size":    null,
+				"canary_settings":       [],
+				"client_certificate_id": "abc123",
+				"description":           null,
+				"documentation_version": null,
+				"stage_name":            "example",
+				"tags":                  null,
+				"variables":             null,
+				"xray_tracing_enabled":  null,
+			},
+			"after_unknown": {
+				"access_log_settings": [],
+				"arn":             true,
+				"canary_settings": [],
+				"deployment_id":   true,
+				"execution_arn":   true,
+				"id":              true,
+				"invoke_url":      true,
+				"rest_api_id":     true,
+				"tags_all":        true,
+				"web_acl_arn":     true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "example",
+		"provider_name":  "registry.terraform.io/hashicorp/aws",
+		"type":           "aws_api_gateway_stage",
+	},
+}
+
+resource_drift = {}
+
+output_changes = {}
+
+raw = {
+	"complete": true,
+	"configuration": {
+		"provider_config": {
+			"aws": {
+				"expressions": {
+					"region": {
+						"constant_value": "us-west-2",
+					},
+				},
+				"full_name": "registry.terraform.io/hashicorp/aws",
+				"name":      "aws",
+			},
+		},
+		"root_module": {
+			"resources": [
+				{
+					"address": "aws_api_gateway_deployment.example",
+					"expressions": {
+						"rest_api_id": {
+							"references": [
+								"aws_api_gateway_rest_api.example.id",
+								"aws_api_gateway_rest_api.example",
+							],
+						},
+						"triggers": {
+							"references": [
+								"aws_api_gateway_rest_api.example.body",
+								"aws_api_gateway_rest_api.example",
+							],
+						},
+					},
+					"mode":                "managed",
+					"name":                "example",
+					"provider_config_key": "aws",
+					"schema_version":      0,
+					"type":                "aws_api_gateway_deployment",
+				},
+				{
+					"address": "aws_api_gateway_method_settings.example",
+					"expressions": {
+						"method_path": {
+							"constant_value": "*/*",
+						},
+						"rest_api_id": {
+							"references": [
+								"aws_api_gateway_rest_api.example.id",
+								"aws_api_gateway_rest_api.example",
+							],
+						},
+						"settings": [
+							{
+								"logging_level": {
+									"constant_value": "INFO",
+								},
+								"metrics_enabled": {
+									"constant_value": true,
+								},
+							},
+						],
+						"stage_name": {
+							"references": [
+								"aws_api_gateway_stage.example.stage_name",
+								"aws_api_gateway_stage.example",
+							],
+						},
+					},
+					"mode":                "managed",
+					"name":                "example",
+					"provider_config_key": "aws",
+					"schema_version":      0,
+					"type":                "aws_api_gateway_method_settings",
+				},
+				{
+					"address": "aws_api_gateway_rest_api.example",
+					"expressions": {
+						"body": {},
+						"name": {
+							"constant_value": "example",
+						},
+					},
+					"mode":                "managed",
+					"name":                "example",
+					"provider_config_key": "aws",
+					"schema_version":      0,
+					"type":                "aws_api_gateway_rest_api",
+				},
+				{
+					"address": "aws_api_gateway_stage.example",
+					"expressions": {
+						"client_certificate_id": {
+							"constant_value": "abc123",
+						},
+						"deployment_id": {
+							"references": [
+								"aws_api_gateway_deployment.example.id",
+								"aws_api_gateway_deployment.example",
+							],
+						},
+						"rest_api_id": {
+							"references": [
+								"aws_api_gateway_rest_api.example.id",
+								"aws_api_gateway_rest_api.example",
+							],
+						},
+						"stage_name": {
+							"constant_value": "example",
+						},
+					},
+					"mode":                "managed",
+					"name":                "example",
+					"provider_config_key": "aws",
+					"schema_version":      0,
+					"type":                "aws_api_gateway_stage",
+				},
+			],
+		},
+	},
+	"format_version": "1.2",
+	"planned_values": {
+		"root_module": {
+			"resources": [
+				{
+					"address":        "aws_api_gateway_deployment.example",
+					"mode":           "managed",
+					"name":           "example",
+					"provider_name":  "registry.terraform.io/hashicorp/aws",
+					"schema_version": 0,
+					"sensitive_values": {
+						"canary_settings": [],
+						"triggers":        {},
+					},
+					"type": "aws_api_gateway_deployment",
+					"values": {
+						"canary_settings":   [],
+						"description":       null,
+						"stage_description": null,
+						"stage_name":        null,
+						"triggers": {
+							"redeployment": "145be397ea51cabb14595b0f0ace006017953f0a",
+						},
+						"variables": null,
+					},
+				},
+				{
+					"address":        "aws_api_gateway_method_settings.example",
+					"mode":           "managed",
+					"name":           "example",
+					"provider_name":  "registry.terraform.io/hashicorp/aws",
+					"schema_version": 0,
+					"sensitive_values": {
+						"settings": [
+							{},
+						],
+					},
+					"type": "aws_api_gateway_method_settings",
+					"values": {
+						"method_path": "*/*",
+						"settings": [
+							{
+								"logging_level":          "INFO",
+								"metrics_enabled":        true,
+								"throttling_burst_limit": -1,
+								"throttling_rate_limit":  -1,
+							},
+						],
+						"stage_name": "example",
+					},
+				},
+				{
+					"address":        "aws_api_gateway_rest_api.example",
+					"mode":           "managed",
+					"name":           "example",
+					"provider_name":  "registry.terraform.io/hashicorp/aws",
+					"schema_version": 0,
+					"sensitive_values": {
+						"binary_media_types":     [],
+						"endpoint_configuration": [],
+						"tags_all":               {},
+					},
+					"type": "aws_api_gateway_rest_api",
+					"values": {
+						"body":              "{\"info\":{\"title\":\"example\",\"version\":\"1.0\"},\"openapi\":\"3.0.1\",\"paths\":{\"/path1\":{\"get\":{\"x-amazon-apigateway-integration\":{\"httpMethod\":\"GET\",\"payloadFormatVersion\":\"1.0\",\"type\":\"HTTP_PROXY\",\"uri\":\"https://ip-ranges.amazonaws.com/ip-ranges.json\"}}}}}",
+						"fail_on_warnings":  null,
+						"name":              "example",
+						"parameters":        null,
+						"put_rest_api_mode": null,
+						"tags":              null,
+					},
+				},
+				{
+					"address":        "aws_api_gateway_stage.example",
+					"mode":           "managed",
+					"name":           "example",
+					"provider_name":  "registry.terraform.io/hashicorp/aws",
+					"schema_version": 0,
+					"sensitive_values": {
+						"access_log_settings": [],
+						"canary_settings":     [],
+						"tags_all":            {},
+					},
+					"type": "aws_api_gateway_stage",
+					"values": {
+						"access_log_settings":   [],
+						"cache_cluster_enabled": null,
+						"cache_cluster_size":    null,
+						"canary_settings":       [],
+						"client_certificate_id": "abc123",
+						"description":           null,
+						"documentation_version": null,
+						"stage_name":            "example",
+						"tags":                  null,
+						"variables":             null,
+						"xray_tracing_enabled":  null,
+					},
+				},
+			],
+		},
+	},
+	"relevant_attributes": [
+		{
+			"attribute": [
+				"id",
+			],
+			"resource": "aws_api_gateway_rest_api.example",
+		},
+		{
+			"attribute": [
+				"body",
+			],
+			"resource": "aws_api_gateway_rest_api.example",
+		},
+		{
+			"attribute": [
+				"id",
+			],
+			"resource": "aws_api_gateway_deployment.example",
+		},
+		{
+			"attribute": [
+				"stage_name",
+			],
+			"resource": "aws_api_gateway_stage.example",
+		},
+	],
+	"resource_changes": [
+		{
+			"address": "aws_api_gateway_deployment.example",
+			"change": {
+				"actions": [
+					"create",
+				],
+				"after": {
+					"canary_settings":   [],
+					"description":       null,
+					"stage_description": null,
+					"stage_name":        null,
+					"triggers": {
+						"redeployment": "145be397ea51cabb14595b0f0ace006017953f0a",
+					},
+					"variables": null,
+				},
+				"after_sensitive": {
+					"canary_settings": [],
+					"triggers":        {},
+				},
+				"after_unknown": {
+					"canary_settings": [],
+					"created_date":    true,
+					"execution_arn":   true,
+					"id":              true,
+					"invoke_url":      true,
+					"rest_api_id":     true,
+					"triggers":        {},
+				},
+				"before":           null,
+				"before_sensitive": false,
+			},
+			"mode":          "managed",
+			"name":          "example",
+			"provider_name": "registry.terraform.io/hashicorp/aws",
+			"type":          "aws_api_gateway_deployment",
+		},
+		{
+			"address": "aws_api_gateway_method_settings.example",
+			"change": {
+				"actions": [
+					"create",
+				],
+				"after": {
+					"method_path": "*/*",
+					"settings": [
+						{
+							"logging_level":          "INFO",
+							"metrics_enabled":        true,
+							"throttling_burst_limit": -1,
+							"throttling_rate_limit":  -1,
+						},
+					],
+					"stage_name": "example",
+				},
+				"after_sensitive": {
+					"settings": [
+						{},
+					],
+				},
+				"after_unknown": {
+					"id":          true,
+					"rest_api_id": true,
+					"settings": [
+						{
+							"cache_data_encrypted":                       true,
+							"cache_ttl_in_seconds":                       true,
+							"caching_enabled":                            true,
+							"data_trace_enabled":                         true,
+							"require_authorization_for_cache_control":    true,
+							"unauthorized_cache_control_header_strategy": true,
+						},
+					],
+				},
+				"before":           null,
+				"before_sensitive": false,
+			},
+			"mode":          "managed",
+			"name":          "example",
+			"provider_name": "registry.terraform.io/hashicorp/aws",
+			"type":          "aws_api_gateway_method_settings",
+		},
+		{
+			"address": "aws_api_gateway_rest_api.example",
+			"change": {
+				"actions": [
+					"create",
+				],
+				"after": {
+					"body":              "{\"info\":{\"title\":\"example\",\"version\":\"1.0\"},\"openapi\":\"3.0.1\",\"paths\":{\"/path1\":{\"get\":{\"x-amazon-apigateway-integration\":{\"httpMethod\":\"GET\",\"payloadFormatVersion\":\"1.0\",\"type\":\"HTTP_PROXY\",\"uri\":\"https://ip-ranges.amazonaws.com/ip-ranges.json\"}}}}}",
+					"fail_on_warnings":  null,
+					"name":              "example",
+					"parameters":        null,
+					"put_rest_api_mode": null,
+					"tags":              null,
+				},
+				"after_sensitive": {
+					"binary_media_types":     [],
+					"endpoint_configuration": [],
+					"tags_all":               {},
+				},
+				"after_unknown": {
+					"api_key_source":               true,
+					"arn":                          true,
+					"binary_media_types":           true,
+					"created_date":                 true,
+					"description":                  true,
+					"disable_execute_api_endpoint": true,
+					"endpoint_configuration":       true,
+					"execution_arn":                true,
+					"id":                           true,
+					"minimum_compression_size": true,
+					"policy":                   true,
+					"root_resource_id":         true,
+					"tags_all":                 true,
+				},
+				"before":           null,
+				"before_sensitive": false,
+			},
+			"mode":          "managed",
+			"name":          "example",
+			"provider_name": "registry.terraform.io/hashicorp/aws",
+			"type":          "aws_api_gateway_rest_api",
+		},
+		{
+			"address": "aws_api_gateway_stage.example",
+			"change": {
+				"actions": [
+					"create",
+				],
+				"after": {
+					"access_log_settings":   [],
+					"cache_cluster_enabled": null,
+					"cache_cluster_size":    null,
+					"canary_settings":       [],
+					"client_certificate_id": "abc123",
+					"description":           null,
+					"documentation_version": null,
+					"stage_name":            "example",
+					"tags":                  null,
+					"variables":             null,
+					"xray_tracing_enabled":  null,
+				},
+				"after_sensitive": {
+					"access_log_settings": [],
+					"canary_settings":     [],
+					"tags_all":            {},
+				},
+				"after_unknown": {
+					"access_log_settings": [],
+					"arn":             true,
+					"canary_settings": [],
+					"deployment_id":   true,
+					"execution_arn":   true,
+					"id":              true,
+					"invoke_url":      true,
+					"rest_api_id":     true,
+					"tags_all":        true,
+					"web_acl_arn":     true,
+				},
+				"before":           null,
+				"before_sensitive": false,
+			},
+			"mode":          "managed",
+			"name":          "example",
+			"provider_name": "registry.terraform.io/hashicorp/aws",
+			"type":          "aws_api_gateway_stage",
+		},
+	],
+	"terraform_version": "1.9.5",
+	"timestamp":         "2024-10-08T20:56:52Z",
+}

--- a/policies/test/api-gateway-rest-configure-ssl-certificates/success-client-certificate-id-is-not-null.hcl
+++ b/policies/test/api-gateway-rest-configure-ssl-certificates/success-client-certificate-id-is-not-null.hcl
@@ -1,0 +1,23 @@
+mock "tfplan/v2" {
+	module {
+		source = "./mocks/policy-success-client-certificate-id-is-not-null/mock-tfplan-v2.sentinel"
+	}
+}
+
+
+
+import "plugin" "tfresources" {
+	source = "../../../plugins/darwin/arm64/sentinel-plugin-tfresources"
+}
+
+mock "report" {
+	module {
+		source = "../../../modules/mocks/report/report.sentinel"
+	}
+}
+
+test {
+	rules = {
+		main = true
+	}
+}

--- a/sentinel.hcl
+++ b/sentinel.hcl
@@ -544,3 +544,8 @@ policy "api-gateway-rest-have-x-ray-tracing-enabled" {
   source = "./policies/api-gateway-rest-have-x-ray-tracing-enabled.sentinel"
   enforcement_level = "advisory"
 }
+
+policy "api-gateway-rest-configure-ssl-certificates" {
+  source = "./policies/api-gateway-rest-configure-ssl-certificates.sentinel"
+  enforcement_level = "advisory"
+}

--- a/tests/acceptance/api-gateway-rest-configure-ssl-certificates/cases/client-certificate-id-is-not-null/backend.tf
+++ b/tests/acceptance/api-gateway-rest-configure-ssl-certificates/cases/client-certificate-id-is-not-null/backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  cloud {
+    workspaces {
+      name = "api-gateway-rest-configure-ssl-certificates"
+    }
+  }
+}

--- a/tests/acceptance/api-gateway-rest-configure-ssl-certificates/cases/client-certificate-id-is-not-null/main.tf
+++ b/tests/acceptance/api-gateway-rest-configure-ssl-certificates/cases/client-certificate-id-is-not-null/main.tf
@@ -1,0 +1,57 @@
+provider "aws" {
+  region = "us-west-2"
+}
+
+resource "aws_api_gateway_rest_api" "example" {
+  body = jsonencode({
+    openapi = "3.0.1"
+    info = {
+      title   = "example"
+      version = "1.0"
+    }
+    paths = {
+      "/path1" = {
+        get = {
+          x-amazon-apigateway-integration = {
+            httpMethod           = "GET"
+            payloadFormatVersion = "1.0"
+            type                 = "HTTP_PROXY"
+            uri                  = "https://ip-ranges.amazonaws.com/ip-ranges.json"
+          }
+        }
+      }
+    }
+  })
+
+  name = "example"
+}
+
+resource "aws_api_gateway_deployment" "example" {
+  rest_api_id = aws_api_gateway_rest_api.example.id
+
+  triggers = {
+    redeployment = sha1(jsonencode(aws_api_gateway_rest_api.example.body))
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_api_gateway_stage" "example" {
+  deployment_id         = aws_api_gateway_deployment.example.id
+  rest_api_id           = aws_api_gateway_rest_api.example.id
+  stage_name            = "example"
+  client_certificate_id = "abc123"
+}
+
+resource "aws_api_gateway_method_settings" "example" {
+  rest_api_id = aws_api_gateway_rest_api.example.id
+  stage_name  = aws_api_gateway_stage.example.stage_name
+  method_path = "*/*"
+
+  settings {
+    metrics_enabled = true
+    logging_level   = "INFO"
+  }
+}

--- a/tests/acceptance/api-gateway-rest-configure-ssl-certificates/cases/client-certificate-id-is-null/backend.tf
+++ b/tests/acceptance/api-gateway-rest-configure-ssl-certificates/cases/client-certificate-id-is-null/backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  cloud {
+    workspaces {
+      name = "api-gateway-rest-configure-ssl-certificates"
+    }
+  }
+}

--- a/tests/acceptance/api-gateway-rest-configure-ssl-certificates/cases/client-certificate-id-is-null/main.tf
+++ b/tests/acceptance/api-gateway-rest-configure-ssl-certificates/cases/client-certificate-id-is-null/main.tf
@@ -1,0 +1,56 @@
+provider "aws" {
+  region = "us-west-2"
+}
+
+resource "aws_api_gateway_rest_api" "example" {
+  body = jsonencode({
+    openapi = "3.0.1"
+    info = {
+      title   = "example"
+      version = "1.0"
+    }
+    paths = {
+      "/path1" = {
+        get = {
+          x-amazon-apigateway-integration = {
+            httpMethod           = "GET"
+            payloadFormatVersion = "1.0"
+            type                 = "HTTP_PROXY"
+            uri                  = "https://ip-ranges.amazonaws.com/ip-ranges.json"
+          }
+        }
+      }
+    }
+  })
+
+  name = "example"
+}
+
+resource "aws_api_gateway_deployment" "example" {
+  rest_api_id = aws_api_gateway_rest_api.example.id
+
+  triggers = {
+    redeployment = sha1(jsonencode(aws_api_gateway_rest_api.example.body))
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_api_gateway_stage" "example" {
+  deployment_id = aws_api_gateway_deployment.example.id
+  rest_api_id   = aws_api_gateway_rest_api.example.id
+  stage_name    = "example"
+}
+
+resource "aws_api_gateway_method_settings" "example" {
+  rest_api_id = aws_api_gateway_rest_api.example.id
+  stage_name  = aws_api_gateway_stage.example.stage_name
+  method_path = "*/*"
+
+  settings {
+    metrics_enabled = true
+    logging_level   = "INFO"
+  }
+}

--- a/tests/acceptance/api-gateway-rest-configure-ssl-certificates/test-config.hcl
+++ b/tests/acceptance/api-gateway-rest-configure-ssl-certificates/test-config.hcl
@@ -1,0 +1,17 @@
+name = "api-gateway-rest-configure-ssl-certificates"
+
+disabled = false
+
+case "Client certificate ID is not null" {
+    path = "./cases/client-certificate-id-is-not-null"
+    expectation {
+        result = true
+    }
+}
+
+case "Client certificate ID is null" {
+    path = "./cases/client-certificate-id-is-null"
+    expectation {
+        result = false
+    }
+}


### PR DESCRIPTION
## Changes proposed in this PR:
- Policy for API Gateway REST API stages should be configured to use SSL certificates for backend authentication

## Documentation
- [AWS Standard](https://docs.aws.amazon.com/securityhub/latest/userguide/apigateway-controls.html#apigateway-2)
- [Policy details](https://docs.aws.amazon.com/securityhub/latest/userguide/apigateway-controls.html#apigateway-2)

## AWS Provider version
<!-- Add information about the provider version against which the policy was tested/developed with. This will later help us when we deal with documentation.Add any nuances that you've observed around provider versions. For example, some attributes will only be present in a certain version of a provider and we need to clearly document that so that users use the expected version.-->

## How I've tested this PR:

## Checklist:
- [x] Tests added