### PR TITLE
Added GuardDuty should be enabled

### DIFF
--- a/docs/policies/guardduty-should-be-enabled.md
+++ b/docs/policies/guardduty-should-be-enabled.md
@@ -1,0 +1,67 @@
+# GuardDuty should be enabled
+
+| Provider            | Category           |
+|---------------------|--------------------|
+| Amazon Web Services | Detection services |
+
+## Description
+
+This control checks whether Amazon GuardDuty is enabled in your GuardDuty account and Region.
+
+It is highly recommended that you enable GuardDuty in all supported AWS Regions. Doing so allows GuardDuty to generate findings about unauthorized or unusual activity, even in Regions that you do not actively use. This also allows GuardDuty to monitor CloudTrail events for global AWS services such as IAM.
+
+This rule is covered by the [guardduty-should-be-enabled](../../policies/guardduty-should-be-enabled.sentinel) policy.
+
+## Policy Results (Pass)
+```bash
+trace:
+      Pass - guardduty-should-be-enabled.sentinel
+
+      Description:
+        This control checks whether 'aws_guardduty_detector' is enabled in your
+        GuardDuty account and Region.
+
+      Print messages:
+
+      → → Overall Result: true
+
+      This result means that all resources have passed the policy check for the policy guardduty-should-be-enabled.
+
+      ✓ Found 0 resource violations
+
+      guardduty-should-be-enabled.sentinel:50:1 - Rule "main"
+        Value:
+          true
+```
+
+---
+
+## Policy Results (Fail)
+```bash
+trace:
+      Fail - guardduty-should-be-enabled.sentinel
+
+      Description:
+        This control checks whether 'aws_guardduty_detector' is enabled in your
+        GuardDuty account and Region.
+
+      Print messages:
+
+      → → Overall Result: false
+
+      This result means that not all resources passed the policy check and the protected behavior is not allowed for the policy guardduty-should-be-enabled.
+
+      Found 1 resource violations
+
+      → Module name: root
+        ↳ Resource Address: aws_guardduty_detector.MyDetector
+          | ✗ failed
+          | 'aws_guardduty_detector' is enabled in your GuardDuty account and Region. Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/guardduty-controls.html#guardduty-1 for more details.
+
+
+      guardduty-should-be-enabled.sentinel:50:1 - Rule "main"
+        Value:
+          false
+```
+
+---

--- a/policies/guardduty-should-be-enabled.sentinel
+++ b/policies/guardduty-should-be-enabled.sentinel
@@ -1,0 +1,52 @@
+# This control checks whether 'aws_guardduty_detector' is enabled in your GuardDuty account and Region.
+
+import "tfplan/v2" as tfplan
+import "tfresources" as tf
+import "report" as report
+import "collection" as collection
+import "collection/maps" as maps
+
+# Constants
+const = {
+	"policy_name":                     "guardduty-should-be-enabled",
+	"resource_aws_guardduty_detector": "aws_guardduty_detector",
+	"message":                         "'aws_guardduty_detector' is enabled in your GuardDuty account and Region. Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/guardduty-controls.html#guardduty-1 for more details.",
+}
+
+# Functions
+
+get_violations = func(resources) {
+	return collection.reject(resources, func(res) {
+		guardduty_detector = maps.get(res, "values.enable", false)
+		if guardduty_detector is null {
+			return false
+		}
+		return guardduty_detector
+	})
+}
+
+# Variables
+
+aws_guardduty_detector = tf.plan(tfplan.planned_values.resources).type(const.resource_aws_guardduty_detector).resources
+violations = get_violations(aws_guardduty_detector)
+
+summary = {
+	"policy_name": const.policy_name,
+	"violations": map violations as _, v {
+		{
+			"address":        v.address,
+			"module_address": v.module_address,
+			"message":        const.message,
+		}
+	},
+}
+
+# Outputs
+
+print(report.generate_policy_report(summary))
+
+# Rules
+
+main = rule {
+	violations is empty
+}

--- a/policies/test/guardduty-should-be-enabled/failure-guarduty-not-enabled.hcl
+++ b/policies/test/guardduty-should-be-enabled/failure-guarduty-not-enabled.hcl
@@ -1,0 +1,23 @@
+mock "tfplan/v2" {
+	module {
+		source = "./mocks/policy-failure-guarduty-not-enabled/mock-tfplan-v2.sentinel"
+	}
+}
+
+
+
+import "plugin" "tfresources" {
+	source = "../../../plugins/darwin/arm64/sentinel-plugin-tfresources"
+}
+
+mock "report" {
+	module {
+		source = "../../../modules/mocks/report/report.sentinel"
+	}
+}
+
+test {
+	rules = {
+		main = false
+	}
+}

--- a/policies/test/guardduty-should-be-enabled/mocks/policy-failure-guarduty-not-enabled/mock-tfplan-v2.sentinel
+++ b/policies/test/guardduty-should-be-enabled/mocks/policy-failure-guarduty-not-enabled/mock-tfplan-v2.sentinel
@@ -1,0 +1,408 @@
+terraform_version = "1.10.2"
+
+planned_values = {
+	"outputs": {},
+	"resources": {
+		"aws_guardduty_detector.MyDetector": {
+			"address":        "aws_guardduty_detector.MyDetector",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "MyDetector",
+			"provider_name":  "registry.terraform.io/hashicorp/aws",
+			"tainted":        false,
+			"type":           "aws_guardduty_detector",
+			"values": {
+				"datasources": [
+					{
+						"kubernetes": [
+							{
+								"audit_logs": [
+									{
+										"enable": false,
+									},
+								],
+							},
+						],
+						"malware_protection": [
+							{
+								"scan_ec2_instance_with_findings": [
+									{
+										"ebs_volumes": [
+											{
+												"enable": true,
+											},
+										],
+									},
+								],
+							},
+						],
+						"s3_logs": [
+							{
+								"enable": true,
+							},
+						],
+					},
+				],
+				"enable": false,
+				"tags":   null,
+			},
+		},
+	},
+}
+
+variables = {}
+
+resource_changes = {
+	"aws_guardduty_detector.MyDetector": {
+		"address": "aws_guardduty_detector.MyDetector",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"datasources": [
+					{
+						"kubernetes": [
+							{
+								"audit_logs": [
+									{
+										"enable": false,
+									},
+								],
+							},
+						],
+						"malware_protection": [
+							{
+								"scan_ec2_instance_with_findings": [
+									{
+										"ebs_volumes": [
+											{
+												"enable": true,
+											},
+										],
+									},
+								],
+							},
+						],
+						"s3_logs": [
+							{
+								"enable": true,
+							},
+						],
+					},
+				],
+				"enable": true,
+				"tags":   null,
+			},
+			"after_unknown": {
+				"account_id": true,
+				"arn":        true,
+				"datasources": [
+					{
+						"kubernetes": [
+							{
+								"audit_logs": [
+									{},
+								],
+							},
+						],
+						"malware_protection": [
+							{
+								"scan_ec2_instance_with_findings": [
+									{
+										"ebs_volumes": [
+											{},
+										],
+									},
+								],
+							},
+						],
+						"s3_logs": [
+							{},
+						],
+					},
+				],
+				"finding_publishing_frequency": true,
+				"id":       true,
+				"tags_all": true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "MyDetector",
+		"provider_name":  "registry.terraform.io/hashicorp/aws",
+		"type":           "aws_guardduty_detector",
+	},
+}
+
+resource_drift = {}
+
+output_changes = {}
+
+raw = {
+	"complete": true,
+	"configuration": {
+		"provider_config": {
+			"aws": {
+				"expressions": {
+					"region": {
+						"constant_value": "us-west-2",
+					},
+				},
+				"full_name": "registry.terraform.io/hashicorp/aws",
+				"name":      "aws",
+			},
+		},
+		"root_module": {
+			"resources": [
+				{
+					"address": "aws_guardduty_detector.MyDetector",
+					"expressions": {
+						"datasources": [
+							{
+								"kubernetes": [
+									{
+										"audit_logs": [
+											{
+												"enable": {
+													"constant_value": false,
+												},
+											},
+										],
+									},
+								],
+								"malware_protection": [
+									{
+										"scan_ec2_instance_with_findings": [
+											{
+												"ebs_volumes": [
+													{
+														"enable": {
+															"constant_value": true,
+														},
+													},
+												],
+											},
+										],
+									},
+								],
+								"s3_logs": [
+									{
+										"enable": {
+											"constant_value": true,
+										},
+									},
+								],
+							},
+						],
+						"enable": {
+							"constant_value": true,
+						},
+					},
+					"mode":                "managed",
+					"name":                "MyDetector",
+					"provider_config_key": "aws",
+					"schema_version":      0,
+					"type":                "aws_guardduty_detector",
+				},
+			],
+		},
+	},
+	"format_version": "1.2",
+	"planned_values": {
+		"root_module": {
+			"resources": [
+				{
+					"address":        "aws_guardduty_detector.MyDetector",
+					"mode":           "managed",
+					"name":           "MyDetector",
+					"provider_name":  "registry.terraform.io/hashicorp/aws",
+					"schema_version": 0,
+					"sensitive_values": {
+						"datasources": [
+							{
+								"kubernetes": [
+									{
+										"audit_logs": [
+											{},
+										],
+									},
+								],
+								"malware_protection": [
+									{
+										"scan_ec2_instance_with_findings": [
+											{
+												"ebs_volumes": [
+													{},
+												],
+											},
+										],
+									},
+								],
+								"s3_logs": [
+									{},
+								],
+							},
+						],
+						"tags_all": {},
+					},
+					"type": "aws_guardduty_detector",
+					"values": {
+						"datasources": [
+							{
+								"kubernetes": [
+									{
+										"audit_logs": [
+											{
+												"enable": false,
+											},
+										],
+									},
+								],
+								"malware_protection": [
+									{
+										"scan_ec2_instance_with_findings": [
+											{
+												"ebs_volumes": [
+													{
+														"enable": true,
+													},
+												],
+											},
+										],
+									},
+								],
+								"s3_logs": [
+									{
+										"enable": true,
+									},
+								],
+							},
+						],
+						"enable": true,
+						"tags":   null,
+					},
+				},
+			],
+		},
+	},
+	"resource_changes": [
+		{
+			"address": "aws_guardduty_detector.MyDetector",
+			"change": {
+				"actions": [
+					"create",
+				],
+				"after": {
+					"datasources": [
+						{
+							"kubernetes": [
+								{
+									"audit_logs": [
+										{
+											"enable": false,
+										},
+									],
+								},
+							],
+							"malware_protection": [
+								{
+									"scan_ec2_instance_with_findings": [
+										{
+											"ebs_volumes": [
+												{
+													"enable": true,
+												},
+											],
+										},
+									],
+								},
+							],
+							"s3_logs": [
+								{
+									"enable": true,
+								},
+							],
+						},
+					],
+					"enable": true,
+					"tags":   null,
+				},
+				"after_sensitive": {
+					"datasources": [
+						{
+							"kubernetes": [
+								{
+									"audit_logs": [
+										{},
+									],
+								},
+							],
+							"malware_protection": [
+								{
+									"scan_ec2_instance_with_findings": [
+										{
+											"ebs_volumes": [
+												{},
+											],
+										},
+									],
+								},
+							],
+							"s3_logs": [
+								{},
+							],
+						},
+					],
+					"tags_all": {},
+				},
+				"after_unknown": {
+					"account_id": true,
+					"arn":        true,
+					"datasources": [
+						{
+							"kubernetes": [
+								{
+									"audit_logs": [
+										{},
+									],
+								},
+							],
+							"malware_protection": [
+								{
+									"scan_ec2_instance_with_findings": [
+										{
+											"ebs_volumes": [
+												{},
+											],
+										},
+									],
+								},
+							],
+							"s3_logs": [
+								{},
+							],
+						},
+					],
+					"finding_publishing_frequency": true,
+					"id":       true,
+					"tags_all": true,
+				},
+				"before":           null,
+				"before_sensitive": false,
+			},
+			"mode":          "managed",
+			"name":          "MyDetector",
+			"provider_name": "registry.terraform.io/hashicorp/aws",
+			"type":          "aws_guardduty_detector",
+		},
+	],
+	"terraform_version": "1.10.2",
+	"timestamp":         "2025-01-07T21:32:10Z",
+}

--- a/policies/test/guardduty-should-be-enabled/mocks/policy-success-guarduty-is-enabled/mock-tfplan-v2.sentinel
+++ b/policies/test/guardduty-should-be-enabled/mocks/policy-success-guarduty-is-enabled/mock-tfplan-v2.sentinel
@@ -1,0 +1,408 @@
+terraform_version = "1.10.2"
+
+planned_values = {
+	"outputs": {},
+	"resources": {
+		"aws_guardduty_detector.MyDetector": {
+			"address":        "aws_guardduty_detector.MyDetector",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "MyDetector",
+			"provider_name":  "registry.terraform.io/hashicorp/aws",
+			"tainted":        false,
+			"type":           "aws_guardduty_detector",
+			"values": {
+				"datasources": [
+					{
+						"kubernetes": [
+							{
+								"audit_logs": [
+									{
+										"enable": false,
+									},
+								],
+							},
+						],
+						"malware_protection": [
+							{
+								"scan_ec2_instance_with_findings": [
+									{
+										"ebs_volumes": [
+											{
+												"enable": true,
+											},
+										],
+									},
+								],
+							},
+						],
+						"s3_logs": [
+							{
+								"enable": true,
+							},
+						],
+					},
+				],
+				"enable": true,
+				"tags":   null,
+			},
+		},
+	},
+}
+
+variables = {}
+
+resource_changes = {
+	"aws_guardduty_detector.MyDetector": {
+		"address": "aws_guardduty_detector.MyDetector",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"datasources": [
+					{
+						"kubernetes": [
+							{
+								"audit_logs": [
+									{
+										"enable": false,
+									},
+								],
+							},
+						],
+						"malware_protection": [
+							{
+								"scan_ec2_instance_with_findings": [
+									{
+										"ebs_volumes": [
+											{
+												"enable": true,
+											},
+										],
+									},
+								],
+							},
+						],
+						"s3_logs": [
+							{
+								"enable": true,
+							},
+						],
+					},
+				],
+				"enable": true,
+				"tags":   null,
+			},
+			"after_unknown": {
+				"account_id": true,
+				"arn":        true,
+				"datasources": [
+					{
+						"kubernetes": [
+							{
+								"audit_logs": [
+									{},
+								],
+							},
+						],
+						"malware_protection": [
+							{
+								"scan_ec2_instance_with_findings": [
+									{
+										"ebs_volumes": [
+											{},
+										],
+									},
+								],
+							},
+						],
+						"s3_logs": [
+							{},
+						],
+					},
+				],
+				"finding_publishing_frequency": true,
+				"id":       true,
+				"tags_all": true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "MyDetector",
+		"provider_name":  "registry.terraform.io/hashicorp/aws",
+		"type":           "aws_guardduty_detector",
+	},
+}
+
+resource_drift = {}
+
+output_changes = {}
+
+raw = {
+	"complete": true,
+	"configuration": {
+		"provider_config": {
+			"aws": {
+				"expressions": {
+					"region": {
+						"constant_value": "us-west-2",
+					},
+				},
+				"full_name": "registry.terraform.io/hashicorp/aws",
+				"name":      "aws",
+			},
+		},
+		"root_module": {
+			"resources": [
+				{
+					"address": "aws_guardduty_detector.MyDetector",
+					"expressions": {
+						"datasources": [
+							{
+								"kubernetes": [
+									{
+										"audit_logs": [
+											{
+												"enable": {
+													"constant_value": false,
+												},
+											},
+										],
+									},
+								],
+								"malware_protection": [
+									{
+										"scan_ec2_instance_with_findings": [
+											{
+												"ebs_volumes": [
+													{
+														"enable": {
+															"constant_value": true,
+														},
+													},
+												],
+											},
+										],
+									},
+								],
+								"s3_logs": [
+									{
+										"enable": {
+											"constant_value": true,
+										},
+									},
+								],
+							},
+						],
+						"enable": {
+							"constant_value": true,
+						},
+					},
+					"mode":                "managed",
+					"name":                "MyDetector",
+					"provider_config_key": "aws",
+					"schema_version":      0,
+					"type":                "aws_guardduty_detector",
+				},
+			],
+		},
+	},
+	"format_version": "1.2",
+	"planned_values": {
+		"root_module": {
+			"resources": [
+				{
+					"address":        "aws_guardduty_detector.MyDetector",
+					"mode":           "managed",
+					"name":           "MyDetector",
+					"provider_name":  "registry.terraform.io/hashicorp/aws",
+					"schema_version": 0,
+					"sensitive_values": {
+						"datasources": [
+							{
+								"kubernetes": [
+									{
+										"audit_logs": [
+											{},
+										],
+									},
+								],
+								"malware_protection": [
+									{
+										"scan_ec2_instance_with_findings": [
+											{
+												"ebs_volumes": [
+													{},
+												],
+											},
+										],
+									},
+								],
+								"s3_logs": [
+									{},
+								],
+							},
+						],
+						"tags_all": {},
+					},
+					"type": "aws_guardduty_detector",
+					"values": {
+						"datasources": [
+							{
+								"kubernetes": [
+									{
+										"audit_logs": [
+											{
+												"enable": false,
+											},
+										],
+									},
+								],
+								"malware_protection": [
+									{
+										"scan_ec2_instance_with_findings": [
+											{
+												"ebs_volumes": [
+													{
+														"enable": true,
+													},
+												],
+											},
+										],
+									},
+								],
+								"s3_logs": [
+									{
+										"enable": true,
+									},
+								],
+							},
+						],
+						"enable": true,
+						"tags":   null,
+					},
+				},
+			],
+		},
+	},
+	"resource_changes": [
+		{
+			"address": "aws_guardduty_detector.MyDetector",
+			"change": {
+				"actions": [
+					"create",
+				],
+				"after": {
+					"datasources": [
+						{
+							"kubernetes": [
+								{
+									"audit_logs": [
+										{
+											"enable": false,
+										},
+									],
+								},
+							],
+							"malware_protection": [
+								{
+									"scan_ec2_instance_with_findings": [
+										{
+											"ebs_volumes": [
+												{
+													"enable": true,
+												},
+											],
+										},
+									],
+								},
+							],
+							"s3_logs": [
+								{
+									"enable": true,
+								},
+							],
+						},
+					],
+					"enable": true,
+					"tags":   null,
+				},
+				"after_sensitive": {
+					"datasources": [
+						{
+							"kubernetes": [
+								{
+									"audit_logs": [
+										{},
+									],
+								},
+							],
+							"malware_protection": [
+								{
+									"scan_ec2_instance_with_findings": [
+										{
+											"ebs_volumes": [
+												{},
+											],
+										},
+									],
+								},
+							],
+							"s3_logs": [
+								{},
+							],
+						},
+					],
+					"tags_all": {},
+				},
+				"after_unknown": {
+					"account_id": true,
+					"arn":        true,
+					"datasources": [
+						{
+							"kubernetes": [
+								{
+									"audit_logs": [
+										{},
+									],
+								},
+							],
+							"malware_protection": [
+								{
+									"scan_ec2_instance_with_findings": [
+										{
+											"ebs_volumes": [
+												{},
+											],
+										},
+									],
+								},
+							],
+							"s3_logs": [
+								{},
+							],
+						},
+					],
+					"finding_publishing_frequency": true,
+					"id":       true,
+					"tags_all": true,
+				},
+				"before":           null,
+				"before_sensitive": false,
+			},
+			"mode":          "managed",
+			"name":          "MyDetector",
+			"provider_name": "registry.terraform.io/hashicorp/aws",
+			"type":          "aws_guardduty_detector",
+		},
+	],
+	"terraform_version": "1.10.2",
+	"timestamp":         "2025-01-07T21:36:07Z",
+}

--- a/policies/test/guardduty-should-be-enabled/success-guarduty-is-enabled.hcl
+++ b/policies/test/guardduty-should-be-enabled/success-guarduty-is-enabled.hcl
@@ -1,0 +1,23 @@
+mock "tfplan/v2" {
+	module {
+		source = "./mocks/policy-success-guarduty-is-enabled/mock-tfplan-v2.sentinel"
+	}
+}
+
+
+
+import "plugin" "tfresources" {
+	source = "../../../plugins/darwin/arm64/sentinel-plugin-tfresources"
+}
+
+mock "report" {
+	module {
+		source = "../../../modules/mocks/report/report.sentinel"
+	}
+}
+
+test {
+	rules = {
+		main = true
+	}
+}

--- a/sentinel.hcl
+++ b/sentinel.hcl
@@ -834,3 +834,8 @@ policy "fsx-lustre-copy-tags-to-backups" {
   source = "./policies/fsx-lustre-copy-tags-to-backups.sentinel"
   enforcement_level = "advisory"
 }
+
+policy "guardduty-should-be-enabled" {
+  source = "./policies/guardduty-should-be-enabled.sentinel"
+  enforcement_level = "advisory"
+}

--- a/tests/acceptance/guardduty-should-be-enabled/cases/guarduty-is-enabled/backend.tf
+++ b/tests/acceptance/guardduty-should-be-enabled/cases/guarduty-is-enabled/backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  cloud {
+    workspaces {
+      name = "guardduty-should-be-enabled"
+    }
+  }
+}

--- a/tests/acceptance/guardduty-should-be-enabled/cases/guarduty-is-enabled/main.tf
+++ b/tests/acceptance/guardduty-should-be-enabled/cases/guarduty-is-enabled/main.tf
@@ -1,0 +1,25 @@
+provider "aws" {
+  region = "us-west-2"
+}
+
+resource "aws_guardduty_detector" "MyDetector" {
+  enable = true
+
+  datasources {
+    s3_logs {
+      enable = true
+    }
+    kubernetes {
+      audit_logs {
+        enable = false
+      }
+    }
+    malware_protection {
+      scan_ec2_instance_with_findings {
+        ebs_volumes {
+          enable = true
+        }
+      }
+    }
+  }
+}

--- a/tests/acceptance/guardduty-should-be-enabled/cases/guarduty-not-enabled/backend.tf
+++ b/tests/acceptance/guardduty-should-be-enabled/cases/guarduty-not-enabled/backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  cloud {
+    workspaces {
+      name = "guardduty-should-be-enabled"
+    }
+  }
+}

--- a/tests/acceptance/guardduty-should-be-enabled/cases/guarduty-not-enabled/main.tf
+++ b/tests/acceptance/guardduty-should-be-enabled/cases/guarduty-not-enabled/main.tf
@@ -1,0 +1,25 @@
+provider "aws" {
+  region = "us-west-2"
+}
+
+resource "aws_guardduty_detector" "MyDetector" {
+  enable = false
+
+  datasources {
+    s3_logs {
+      enable = true
+    }
+    kubernetes {
+      audit_logs {
+        enable = false
+      }
+    }
+    malware_protection {
+      scan_ec2_instance_with_findings {
+        ebs_volumes {
+          enable = true
+        }
+      }
+    }
+  }
+}

--- a/tests/acceptance/guardduty-should-be-enabled/test-config.hcl
+++ b/tests/acceptance/guardduty-should-be-enabled/test-config.hcl
@@ -1,0 +1,17 @@
+name = "guardduty-should-be-enabled"
+	
+disabled = false
+
+case "guarduty-is-enabled" {	
+    path = "./cases/guarduty-is-enabled"
+	expectation {
+		result = true
+	}
+}
+
+case "guarduty-not-enabled" {
+	path = "./cases/guarduty-not-enabled"
+	expectation {
+		result = false
+	}
+}


### PR DESCRIPTION
## Changes proposed in this PR:
- Policy for GuardDuty should be enabled

## Documentation
- [AWS Standard](https://docs.aws.amazon.com/securityhub/latest/userguide/guardduty-controls.html#guardduty-1)
- [Policy details](https://docs.aws.amazon.com/securityhub/latest/userguide/guardduty-controls.html#guardduty-1)

## AWS Provider version
<!-- Add information about the provider version against which the policy was tested/developed with. This will later help us when we deal with documentation.Add any nuances that you've observed around provider versions. For example, some attributes will only be present in a certain version of a provider and we need to clearly document that so that users use the expected version.-->

## How I've tested this PR:

## Checklist:
- [x] Tests added