### PR TITLE
Add Heading for API gateway policy in doc file

### DIFF
--- a/docs/policies/api-gateway-access-logging-should-be-configured.md
+++ b/docs/policies/api-gateway-access-logging-should-be-configured.md
@@ -1,4 +1,4 @@
-# Policy heading goes here
+# Access logging should be configured for API Gateway V2 Stages
 
 | Provider            | Category     |
 |---------------------|--------------|


### PR DESCRIPTION
## Changes proposed in this PR:
-
-

## Documentation
- [AWS Standard](<Link the AWS standard which is supported by this policy>)
- [Policy details](<Link the heading to the policy present in the internal FSBP policies reference document>)

## AWS Provider version
<!-- Add information about the provider version against which the policy was tested/developed with. This will later help us when we deal with documentation.Add any nuances that you've observed around provider versions. For example, some attributes will only be present in a certain version of a provider and we need to clearly document that so that users use the expected version.-->

## How I've tested this PR:

## Checklist:
- [ ] Tests added