### PR TITLE
Fixed the AWS Config Link in the dms-auto-minor-version-upgrade-check policy

### DIFF
--- a/docs/policies/dms-auto-minor-version-upgrade-check.md
+++ b/docs/policies/dms-auto-minor-version-upgrade-check.md
@@ -60,7 +60,7 @@ trace:
       → Module name: root
         ↳ Resource Address: aws_dms_replication_instance.this
           | ✗ failed
-          | Attribute 'publicly_accessible' should be false for AWS DMS Replication Instance. Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/dms-controls.html#dms-1 for more details.
+          | Attribute 'publicly_accessible' should be false for AWS DMS Replication Instance. Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/dms-controls.html#dms-6 for more details.
 
 
       dms-auto-minor-version-upgrade-check.sentinel:46:1 - Rule "main"

--- a/policies/dms-auto-minor-version-upgrade-check.sentinel
+++ b/policies/dms-auto-minor-version-upgrade-check.sentinel
@@ -10,7 +10,7 @@ import "collection/maps" as maps
 # Constants
 const = {
 	"policy_name": "dms-replication-instances-should-not-be-public",
-	"message":     "Attribute 'publicly_accessible' should be false for AWS DMS Replication Instance. Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/dms-controls.html#dms-1 for more details.",
+	"message":     "Attribute 'publicly_accessible' should be false for AWS DMS Replication Instance. Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/dms-controls.html#dms-6 for more details.",
 	"resource_aws_dms_replication_instance": "aws_dms_replication_instance",
 }
 


### PR DESCRIPTION
## Changes proposed in this PR:
- Fixed the AWS Config Link in the dms-auto-minor-version-upgrade-check policy
-

## Documentation
- [AWS Standard](https://docs.aws.amazon.com/securityhub/latest/userguide/dms-controls.html#dms-6)
- [Policy details](https://docs.aws.amazon.com/securityhub/latest/userguide/dms-controls.html#dms-6)

## AWS Provider version

## How I've tested this PR:

## Checklist:
- [ ] Tests added