### PR TITLE
Added waf-regional-rulegroup-not-empty

### DIFF
--- a/docs/policies/waf-regional-rulegroup-not-empty.md
+++ b/docs/policies/waf-regional-rulegroup-not-empty.md
@@ -1,0 +1,67 @@
+# AWS WAF Classic Regional rule groups should have at least one rule
+
+| Provider            | Category                     |
+|---------------------|------------------------------|
+| Amazon Web Services | Secure network configuration |
+
+## Description
+
+This control checks whether an AWS WAF Regional rule group has at least one rule. The control fails if no rules are present within a rule group.
+
+A WAF Regional rule group can contain multiple rules. The rule's conditions allow for traffic inspection and take a defined action (allow, block, or count). Without any rules, the traffic passes without inspection. A WAF Regional rule group with no rules, but with a name or tag suggesting allow, block, or count, could lead to the wrong assumption that one of those actions is occurring.
+
+This rule is covered by the [waf-regional-rulegroup-not-empty](../../policies/waf-regional-rulegroup-not-empty.sentinel) policy.
+
+## Policy Results (Pass)
+```bash
+trace:
+      Pass - waf-regional-rulegroup-not-empty.sentinel
+
+      Description:
+        This policy checks whether an AWS WAF Regional rule group has at least one
+        rule.
+
+      Print messages:
+
+      → → Overall Result: true
+
+      This result means that all resources have passed the policy check for the policy waf-regional-rulegroup-not-empty.
+
+      ✓ Found 0 resource violations
+
+      waf-regional-rulegroup-not-empty.sentinel:48:1 - Rule "main"
+        Value:
+          true
+```
+
+---
+
+## Policy Results (Fail)
+```bash
+trace:
+      Fail - waf-regional-rulegroup-not-empty.sentinel
+
+      Description:
+        This policy checks whether an AWS WAF Regional rule group has at least one
+        rule.
+
+      Print messages:
+
+      → → Overall Result: false
+
+      This result means that not all resources passed the policy check and the protected behavior is not allowed for the policy waf-regional-rulegroup-not-empty.
+
+      Found 1 resource violations
+
+      → Module name: root
+        ↳ Resource Address: aws_wafregional_rule_group.example
+          | ✗ failed
+          | AWS WAF Regional rule group should have at least one rule. Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/waf-controls.html#waf-3 for more details.
+
+
+      waf-regional-rulegroup-not-empty.sentinel:48:1 - Rule "main"
+        Value:
+          false
+```
+
+---

--- a/policies/test/waf-regional-rulegroup-not-empty/failure-waf-regional-rulegroup-is-empty.hcl
+++ b/policies/test/waf-regional-rulegroup-not-empty/failure-waf-regional-rulegroup-is-empty.hcl
@@ -1,0 +1,23 @@
+mock "tfplan/v2" {
+	module {
+		source = "./mocks/policy-failure-waf-regional-rulegroup-is-empty/mock-tfplan-v2.sentinel"
+	}
+}
+
+
+
+import "plugin" "tfresources" {
+	source = "../../../plugins/darwin/arm64/sentinel-plugin-tfresources"
+}
+
+mock "report" {
+	module {
+		source = "../../../modules/mocks/report/report.sentinel"
+	}
+}
+
+test {
+	rules = {
+		main = false
+	}
+}

--- a/policies/test/waf-regional-rulegroup-not-empty/mocks/policy-failure-waf-regional-rulegroup-is-empty/mock-tfplan-v2.sentinel
+++ b/policies/test/waf-regional-rulegroup-not-empty/mocks/policy-failure-waf-regional-rulegroup-is-empty/mock-tfplan-v2.sentinel
@@ -1,0 +1,158 @@
+terraform_version = "1.10.2"
+
+planned_values = {
+	"outputs": {},
+	"resources": {
+		"aws_wafregional_rule_group.example": {
+			"address":        "aws_wafregional_rule_group.example",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "example",
+			"provider_name":  "registry.terraform.io/hashicorp/aws",
+			"tainted":        false,
+			"type":           "aws_wafregional_rule_group",
+			"values": {
+				"activated_rule": [],
+				"metric_name":    "example",
+				"name":           "example",
+				"tags":           null,
+			},
+		},
+	},
+}
+
+variables = {}
+
+resource_changes = {
+	"aws_wafregional_rule_group.example": {
+		"address": "aws_wafregional_rule_group.example",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"activated_rule": [],
+				"metric_name":    "example",
+				"name":           "example",
+				"tags":           null,
+			},
+			"after_unknown": {
+				"activated_rule": [],
+				"arn":            true,
+				"id":             true,
+				"tags_all":       true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "example",
+		"provider_name":  "registry.terraform.io/hashicorp/aws",
+		"type":           "aws_wafregional_rule_group",
+	},
+}
+
+resource_drift = {}
+
+output_changes = {}
+
+raw = {
+	"complete": true,
+	"configuration": {
+		"provider_config": {
+			"aws": {
+				"expressions": {
+					"region": {
+						"constant_value": "us-east-1",
+					},
+				},
+				"full_name": "registry.terraform.io/hashicorp/aws",
+				"name":      "aws",
+			},
+		},
+		"root_module": {
+			"resources": [
+				{
+					"address": "aws_wafregional_rule_group.example",
+					"expressions": {
+						"metric_name": {
+							"constant_value": "example",
+						},
+						"name": {
+							"constant_value": "example",
+						},
+					},
+					"mode":                "managed",
+					"name":                "example",
+					"provider_config_key": "aws",
+					"schema_version":      0,
+					"type":                "aws_wafregional_rule_group",
+				},
+			],
+		},
+	},
+	"format_version": "1.2",
+	"planned_values": {
+		"root_module": {
+			"resources": [
+				{
+					"address":        "aws_wafregional_rule_group.example",
+					"mode":           "managed",
+					"name":           "example",
+					"provider_name":  "registry.terraform.io/hashicorp/aws",
+					"schema_version": 0,
+					"sensitive_values": {
+						"activated_rule": [],
+						"tags_all":       {},
+					},
+					"type": "aws_wafregional_rule_group",
+					"values": {
+						"activated_rule": [],
+						"metric_name":    "example",
+						"name":           "example",
+						"tags":           null,
+					},
+				},
+			],
+		},
+	},
+	"resource_changes": [
+		{
+			"address": "aws_wafregional_rule_group.example",
+			"change": {
+				"actions": [
+					"create",
+				],
+				"after": {
+					"activated_rule": [],
+					"metric_name":    "example",
+					"name":           "example",
+					"tags":           null,
+				},
+				"after_sensitive": {
+					"activated_rule": [],
+					"tags_all":       {},
+				},
+				"after_unknown": {
+					"activated_rule": [],
+					"arn":            true,
+					"id":             true,
+					"tags_all":       true,
+				},
+				"before":           null,
+				"before_sensitive": false,
+			},
+			"mode":          "managed",
+			"name":          "example",
+			"provider_name": "registry.terraform.io/hashicorp/aws",
+			"type":          "aws_wafregional_rule_group",
+		},
+	],
+	"terraform_version": "1.10.2",
+	"timestamp":         "2025-04-01T21:17:46Z",
+}

--- a/policies/test/waf-regional-rulegroup-not-empty/mocks/policy-success-waf-regional-rulegroup-is-not-empty/mock-tfplan-v2.sentinel
+++ b/policies/test/waf-regional-rulegroup-not-empty/mocks/policy-success-waf-regional-rulegroup-is-not-empty/mock-tfplan-v2.sentinel
@@ -1,0 +1,362 @@
+terraform_version = "1.10.2"
+
+planned_values = {
+	"outputs": {},
+	"resources": {
+		"aws_wafregional_rule.example": {
+			"address":        "aws_wafregional_rule.example",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "example",
+			"provider_name":  "registry.terraform.io/hashicorp/aws",
+			"tainted":        false,
+			"type":           "aws_wafregional_rule",
+			"values": {
+				"metric_name": "example",
+				"name":        "example",
+				"predicate":   [],
+				"tags":        null,
+			},
+		},
+		"aws_wafregional_rule_group.example": {
+			"address":        "aws_wafregional_rule_group.example",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "example",
+			"provider_name":  "registry.terraform.io/hashicorp/aws",
+			"tainted":        false,
+			"type":           "aws_wafregional_rule_group",
+			"values": {
+				"activated_rule": [
+					{
+						"action": [
+							{
+								"type": "COUNT",
+							},
+						],
+						"priority": 50,
+						"type":     "REGULAR",
+					},
+				],
+				"metric_name": "example",
+				"name":        "example",
+				"tags":        null,
+			},
+		},
+	},
+}
+
+variables = {}
+
+resource_changes = {
+	"aws_wafregional_rule.example": {
+		"address": "aws_wafregional_rule.example",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"metric_name": "example",
+				"name":        "example",
+				"predicate":   [],
+				"tags":        null,
+			},
+			"after_unknown": {
+				"arn":       true,
+				"id":        true,
+				"predicate": [],
+				"tags_all":  true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "example",
+		"provider_name":  "registry.terraform.io/hashicorp/aws",
+		"type":           "aws_wafregional_rule",
+	},
+	"aws_wafregional_rule_group.example": {
+		"address": "aws_wafregional_rule_group.example",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"activated_rule": [
+					{
+						"action": [
+							{
+								"type": "COUNT",
+							},
+						],
+						"priority": 50,
+						"type":     "REGULAR",
+					},
+				],
+				"metric_name": "example",
+				"name":        "example",
+				"tags":        null,
+			},
+			"after_unknown": {
+				"activated_rule": [
+					{
+						"action": [
+							{},
+						],
+						"rule_id": true,
+					},
+				],
+				"arn":      true,
+				"id":       true,
+				"tags_all": true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "example",
+		"provider_name":  "registry.terraform.io/hashicorp/aws",
+		"type":           "aws_wafregional_rule_group",
+	},
+}
+
+resource_drift = {}
+
+output_changes = {}
+
+raw = {
+	"complete": true,
+	"configuration": {
+		"provider_config": {
+			"aws": {
+				"expressions": {
+					"region": {
+						"constant_value": "us-east-1",
+					},
+				},
+				"full_name": "registry.terraform.io/hashicorp/aws",
+				"name":      "aws",
+			},
+		},
+		"root_module": {
+			"resources": [
+				{
+					"address": "aws_wafregional_rule.example",
+					"expressions": {
+						"metric_name": {
+							"constant_value": "example",
+						},
+						"name": {
+							"constant_value": "example",
+						},
+					},
+					"mode":                "managed",
+					"name":                "example",
+					"provider_config_key": "aws",
+					"schema_version":      0,
+					"type":                "aws_wafregional_rule",
+				},
+				{
+					"address": "aws_wafregional_rule_group.example",
+					"expressions": {
+						"activated_rule": [
+							{
+								"action": [
+									{
+										"type": {
+											"constant_value": "COUNT",
+										},
+									},
+								],
+								"priority": {
+									"constant_value": 50,
+								},
+								"rule_id": {
+									"references": [
+										"aws_wafregional_rule.example.id",
+										"aws_wafregional_rule.example",
+									],
+								},
+							},
+						],
+						"metric_name": {
+							"constant_value": "example",
+						},
+						"name": {
+							"constant_value": "example",
+						},
+					},
+					"mode":                "managed",
+					"name":                "example",
+					"provider_config_key": "aws",
+					"schema_version":      0,
+					"type":                "aws_wafregional_rule_group",
+				},
+			],
+		},
+	},
+	"format_version": "1.2",
+	"planned_values": {
+		"root_module": {
+			"resources": [
+				{
+					"address":        "aws_wafregional_rule.example",
+					"mode":           "managed",
+					"name":           "example",
+					"provider_name":  "registry.terraform.io/hashicorp/aws",
+					"schema_version": 0,
+					"sensitive_values": {
+						"predicate": [],
+						"tags_all":  {},
+					},
+					"type": "aws_wafregional_rule",
+					"values": {
+						"metric_name": "example",
+						"name":        "example",
+						"predicate":   [],
+						"tags":        null,
+					},
+				},
+				{
+					"address":        "aws_wafregional_rule_group.example",
+					"mode":           "managed",
+					"name":           "example",
+					"provider_name":  "registry.terraform.io/hashicorp/aws",
+					"schema_version": 0,
+					"sensitive_values": {
+						"activated_rule": [
+							{
+								"action": [
+									{},
+								],
+							},
+						],
+						"tags_all": {},
+					},
+					"type": "aws_wafregional_rule_group",
+					"values": {
+						"activated_rule": [
+							{
+								"action": [
+									{
+										"type": "COUNT",
+									},
+								],
+								"priority": 50,
+								"type":     "REGULAR",
+							},
+						],
+						"metric_name": "example",
+						"name":        "example",
+						"tags":        null,
+					},
+				},
+			],
+		},
+	},
+	"relevant_attributes": [
+		{
+			"attribute": [
+				"id",
+			],
+			"resource": "aws_wafregional_rule.example",
+		},
+	],
+	"resource_changes": [
+		{
+			"address": "aws_wafregional_rule.example",
+			"change": {
+				"actions": [
+					"create",
+				],
+				"after": {
+					"metric_name": "example",
+					"name":        "example",
+					"predicate":   [],
+					"tags":        null,
+				},
+				"after_sensitive": {
+					"predicate": [],
+					"tags_all":  {},
+				},
+				"after_unknown": {
+					"arn":       true,
+					"id":        true,
+					"predicate": [],
+					"tags_all":  true,
+				},
+				"before":           null,
+				"before_sensitive": false,
+			},
+			"mode":          "managed",
+			"name":          "example",
+			"provider_name": "registry.terraform.io/hashicorp/aws",
+			"type":          "aws_wafregional_rule",
+		},
+		{
+			"address": "aws_wafregional_rule_group.example",
+			"change": {
+				"actions": [
+					"create",
+				],
+				"after": {
+					"activated_rule": [
+						{
+							"action": [
+								{
+									"type": "COUNT",
+								},
+							],
+							"priority": 50,
+							"type":     "REGULAR",
+						},
+					],
+					"metric_name": "example",
+					"name":        "example",
+					"tags":        null,
+				},
+				"after_sensitive": {
+					"activated_rule": [
+						{
+							"action": [
+								{},
+							],
+						},
+					],
+					"tags_all": {},
+				},
+				"after_unknown": {
+					"activated_rule": [
+						{
+							"action": [
+								{},
+							],
+							"rule_id": true,
+						},
+					],
+					"arn":      true,
+					"id":       true,
+					"tags_all": true,
+				},
+				"before":           null,
+				"before_sensitive": false,
+			},
+			"mode":          "managed",
+			"name":          "example",
+			"provider_name": "registry.terraform.io/hashicorp/aws",
+			"type":          "aws_wafregional_rule_group",
+		},
+	],
+	"terraform_version": "1.10.2",
+	"timestamp":         "2025-04-01T21:12:31Z",
+}

--- a/policies/test/waf-regional-rulegroup-not-empty/success-waf-regional-rulegroup-is-not-empty.hcl
+++ b/policies/test/waf-regional-rulegroup-not-empty/success-waf-regional-rulegroup-is-not-empty.hcl
@@ -1,0 +1,23 @@
+mock "tfplan/v2" {
+	module {
+		source = "./mocks/policy-success-waf-regional-rulegroup-is-not-empty/mock-tfplan-v2.sentinel"
+	}
+}
+
+
+
+import "plugin" "tfresources" {
+	source = "../../../plugins/darwin/arm64/sentinel-plugin-tfresources"
+}
+
+mock "report" {
+	module {
+		source = "../../../modules/mocks/report/report.sentinel"
+	}
+}
+
+test {
+	rules = {
+		main = true
+	}
+}

--- a/policies/waf-regional-rulegroup-not-empty.sentinel
+++ b/policies/waf-regional-rulegroup-not-empty.sentinel
@@ -1,0 +1,50 @@
+# This policy checks whether an AWS WAF Regional rule group has at least one rule.
+
+import "tfplan/v2" as tfplan
+import "tfresources" as tf
+import "report" as report
+import "collection" as collection
+import "collection/maps" as maps
+
+# Constants
+const = {
+	"policy_name":                         "waf-regional-rulegroup-not-empty",
+	"resource_aws_wafregional_rule_group": "aws_wafregional_rule_group",
+	"message":        "AWS WAF Regional rule group should have at least one rule. Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/waf-controls.html#waf-3 for more details.",
+	"activated_rule": "activated_rule",
+}
+
+# Functions
+
+get_violations = func(resources) {
+	return collection.reject(resources, func(res) {
+		rules = maps.get(res.values, const.activated_rule, [])
+		return rules is not null and length(rules) > 0
+	})
+}
+
+# Variables
+
+aws_wafregional_rule_group = tf.plan(tfplan.planned_values.resources).type(const.resource_aws_wafregional_rule_group).resources
+violations = get_violations(aws_wafregional_rule_group)
+
+summary = {
+	"policy_name": const.policy_name,
+	"violations": map violations as _, v {
+		{
+			"address":        v.address,
+			"module_address": v.module_address,
+			"message":        const.message,
+		}
+	},
+}
+
+# Outputs
+
+print(report.generate_policy_report(summary))
+
+# Rules
+
+main = rule {
+	violations is empty
+}

--- a/sentinel.hcl
+++ b/sentinel.hcl
@@ -973,3 +973,8 @@ policy "kinesis-firehose-delivery-stream-encrypted" {
   source = "./policies/kinesis-firehose-delivery-stream-encrypted.sentinel"
   enforcement_level = "advisory"
 }
+
+policy "waf-regional-rulegroup-not-empty" {
+  source = "./policies/waf-regional-rulegroup-not-empty.sentinel"
+  enforcement_level = "advisory"
+}

--- a/tests/acceptance/waf-regional-rulegroup-not-empty/cases/rulegroup-is-empty/backend.tf
+++ b/tests/acceptance/waf-regional-rulegroup-not-empty/cases/rulegroup-is-empty/backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  cloud {
+    workspaces {
+      name = "waf-regional-rulegroup-not-empty"
+    }
+  }
+}

--- a/tests/acceptance/waf-regional-rulegroup-not-empty/cases/rulegroup-is-empty/main.tf
+++ b/tests/acceptance/waf-regional-rulegroup-not-empty/cases/rulegroup-is-empty/main.tf
@@ -1,0 +1,8 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+resource "aws_wafregional_rule_group" "example" {
+  name        = "example"
+  metric_name = "example"
+}

--- a/tests/acceptance/waf-regional-rulegroup-not-empty/cases/rulegroup-is-not-empty/backend.tf
+++ b/tests/acceptance/waf-regional-rulegroup-not-empty/cases/rulegroup-is-not-empty/backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  cloud {
+    workspaces {
+      name = "waf-regional-rulegroup-not-empty"
+    }
+  }
+}

--- a/tests/acceptance/waf-regional-rulegroup-not-empty/cases/rulegroup-is-not-empty/main.tf
+++ b/tests/acceptance/waf-regional-rulegroup-not-empty/cases/rulegroup-is-not-empty/main.tf
@@ -1,0 +1,22 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+resource "aws_wafregional_rule" "example" {
+  name        = "example"
+  metric_name = "example"
+}
+
+resource "aws_wafregional_rule_group" "example" {
+  name        = "example"
+  metric_name = "example"
+
+  activated_rule {
+    action {
+      type = "COUNT"
+    }
+
+    priority = 50
+    rule_id  = aws_wafregional_rule.example.id
+  }
+}

--- a/tests/acceptance/waf-regional-rulegroup-not-empty/test-config.hcl
+++ b/tests/acceptance/waf-regional-rulegroup-not-empty/test-config.hcl
@@ -1,0 +1,17 @@
+name = "waf-regional-rulegroup-not-empty"
+
+disabled = false
+
+case "Rulegroup is Empty" {
+    path = "./cases/rulegroup-is-empty"
+    expectation {
+        result = false
+    }
+}
+
+case "Rulegroup is Not Empty" {
+    path = "./cases/rulegroup-is-not-empty"
+    expectation {
+        result = true
+    }
+}


### PR DESCRIPTION
## Changes proposed in this PR:
- Added waf-regional-rulegroup-not-empty

## Documentation
- [AWS Standard](https://docs.aws.amazon.com/securityhub/latest/userguide/waf-controls.html#waf-3)
- [Policy details](https://docs.aws.amazon.com/securityhub/latest/userguide/waf-controls.html#waf-3)

## AWS Provider version
<!-- Add information about the provider version against which the policy was tested/developed with. This will later help us when we deal with documentation.Add any nuances that you've observed around provider versions. For example, some attributes will only be present in a certain version of a provider and we need to clearly document that so that users use the expected version.-->

## How I've tested this PR:

## Checklist:
- [x] Tests added