### PR TITLE
Added the ec2-vpc-default-security-group-no-traffic policy

### DIFF
--- a/docs/policies/ec2-vpc-default-security-group-no-traffic.md
+++ b/docs/policies/ec2-vpc-default-security-group-no-traffic.md
@@ -1,0 +1,81 @@
+# EC2 VPC Default Security Group No Traffic
+
+| Provider            | Category   |
+|---------------------|------------|
+| Amazon Web Services | Networking |
+
+## CIS versions that include this policy
+
+| Version | Included |
+|---------|----------|
+| 1.2.0   | &check;  |
+| 1.4.0   | &check;  |
+| 3.0.0   | &check;  |
+
+## Description
+
+DISCLAIMER - This policy will work well if resources of type `aws_vpc`, `aws_default_vpc`, `aws_default_security_group`,
+`aws_security_group_rule`, `aws_vpc_security_group_ingress_rule`, and `aws_vpc_security_group_egress_rule`
+are present in root module.
+
+This policy checks whether the default security group of a VPC allows inbound or outbound traffic. 
+The policy fails if the security group allows inbound or outbound traffic.
+
+This rule is covered by the [ec2-vpc-default-security-group-no-traffic](https://github.com/hashicorp/policy-library-CIS-Policy-Set-for-AWS-Terraform/blob/main/policies/ec2/ec2-vpc-default-security-group-no-traffic.sentinel) policy.
+
+## Policy Results (Pass)
+```bash
+trace:
+
+    Pass - ec2-vpc-default-security-group-no-traffic.sentinel
+
+    Description:
+    This policy requires resources of type `aws_vpc` to have no traffic for
+    default security group.
+
+    Print messages:
+
+    → → Overall Result: true
+
+    This result means that all resources have passed the policy check for the policy ec2-vpc-default-security-group-no-traffic.
+
+    ✓ Found 0 resource violations
+
+    ec2-vpc-default-security-group-no-traffic.sentinel:66:1 - Rule "main"
+    Value:
+        true
+
+```
+
+---
+
+## Policy Results (Fail)
+```bash
+trace:
+
+    Fail - ec2-vpc-default-security-group-no-traffic.sentinel
+
+    Description:
+      This policy requires resources of type `aws_vpc` to have no traffic for
+      default security group.
+
+    Print messages:
+
+    → → Overall Result: false
+
+    This result means that not all resources passed the policy check and the protected behavior is not allowed for the policy ec2-vpc-default-security-group-no-traffic.
+
+    Found 1 resource violations
+
+    → Module name: root
+       ↳ Resource Address: aws_vpc_security_group_ingress_rule.sgr1
+         | ✗ failed
+         | VPC default security group should not allow inbound and outbound traffic. Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/ec2-controls.html#ec2-2 for more details.
+
+
+    ec2-vpc-default-security-group-no-traffic.sentinel:66:1 - Rule "main"
+      Value:
+        false
+        
+```
+---

--- a/policies/ec2-vpc-default-security-group-no-traffic.sentinel
+++ b/policies/ec2-vpc-default-security-group-no-traffic.sentinel
@@ -1,0 +1,91 @@
+# This policy requires resources of type `aws_vpc` to have no traffic for default security group.
+
+# Imports
+
+import "tfconfig/v2" as tfconfig
+import "tfresources" as tf
+import "report" as report
+import "collection" as collection
+import "collection/maps" as maps
+
+# Constants
+
+const = {
+	"message":                             "VPC default security group should not allow inbound and outbound traffic. Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/ec2-controls.html#ec2-2 for more details.",
+	"policy_name":                         "ec2-vpc-default-security-group-no-traffic",
+	"config":                              "config",
+	"security_group_id":                   "security_group_id",
+	"references":                          "references",
+	"constant_value":                      "constant_value",
+	"resource_aws_default_security_group": "aws_default_security_group",
+	"ingress":                                      "ingress",
+	"egress":                                       "egress",
+	"resource_aws_vpc":                             "aws_vpc",
+	"resource_aws_default_vpc":                     "aws_default_vpc",
+	"resource_aws_security_group_rule":             "aws_security_group_rule",
+	"resource_aws_vpc_security_group_ingress_rule": "aws_vpc_security_group_ingress_rule",
+	"resource_aws_vpc_security_group_egress_rule":  "aws_vpc_security_group_egress_rule",
+}
+
+# Functions
+
+is_default_security_group_of_vpc = func(reference) {
+	return reference matches "aws_default_security_group.(.*).id" or
+		reference matches "aws_vpc.(.*).default_security_group_id$" or
+		reference matches "aws_default_vpc.(.*).default_security_group_id$"
+}
+
+filter_security_group_rule_violations = func(sg_rule_resources) {
+	return collection.reject(sg_rule_resources, func(r) {
+		key = "config.security_group_id.references"
+		val = maps.get(r, key, undefined)
+		return !(val is defined and length(val) > 0 and is_default_security_group_of_vpc(val[0]))
+	})
+}
+
+# Variables
+
+config_resources = tf.config(tfconfig.resources)
+
+default_security_group_resources = config_resources.type(const.resource_aws_default_security_group).resources
+
+violations = []
+
+violations += collection.reject(default_security_group_resources, func(r) {
+	ingress_key = const.config + "." + const.ingress + "." + const.constant_value
+	egress_key = const.config + "." + const.egress + "." + const.constant_value
+	ingress_key_val = maps.get(r, ingress_key, undefined)
+	egress_key_val = maps.get(r, egress_key, undefined)
+	return !((ingress_key_val is defined and length(ingress_key_val) > 0) or
+		(egress_key_val is defined and length(egress_key_val) > 0))
+})
+
+aws_security_group_rule_resources = config_resources.type(const.resource_aws_security_group_rule).resources
+violations += filter_security_group_rule_violations(aws_security_group_rule_resources)
+
+aws_security_group_ingress_rule_resources = config_resources.type(const.resource_aws_vpc_security_group_ingress_rule).resources
+violations += filter_security_group_rule_violations(aws_security_group_ingress_rule_resources)
+
+aws_security_group_egress_rule_resources = config_resources.type(const.resource_aws_vpc_security_group_egress_rule).resources
+violations += filter_security_group_rule_violations(aws_security_group_egress_rule_resources)
+
+summary = {
+	"policy_name": const.policy_name,
+	"violations": map violations as _, v {
+		{
+			"address":        v.address,
+			"module_address": v.module_address,
+			"message":        const.message,
+		}
+	},
+}
+
+# Outputs
+
+print(report.generate_policy_report(summary))
+
+# Rules
+
+main = rule {
+	violations is empty
+}

--- a/policies/test/ec2-vpc-default-security-group-no-traffic/failure-default-security-group-with-egress.hcl
+++ b/policies/test/ec2-vpc-default-security-group-no-traffic/failure-default-security-group-with-egress.hcl
@@ -1,0 +1,22 @@
+
+mock "tfconfig/v2" {
+  module {
+    source = "./mocks/policy-failure-default-security-group-with-egress/mock-tfconfig-v2.sentinel"
+  }
+}
+
+import "plugin" "tfresources" {
+	source = "../../../plugins/darwin/arm64/sentinel-plugin-tfresources"
+}
+
+mock "report" {
+	module {
+		source = "../../../modules/mocks/report/report.sentinel"
+	}
+}
+
+test {
+  rules = {
+    main = false
+  }
+}

--- a/policies/test/ec2-vpc-default-security-group-no-traffic/failure-default-security-group-with-ingress.hcl
+++ b/policies/test/ec2-vpc-default-security-group-no-traffic/failure-default-security-group-with-ingress.hcl
@@ -1,0 +1,22 @@
+
+mock "tfconfig/v2" {
+  module {
+    source = "./mocks/policy-failure-default-security-group-with-ingress/mock-tfconfig-v2.sentinel"
+  }
+}
+
+import "plugin" "tfresources" {
+	source = "../../../plugins/darwin/arm64/sentinel-plugin-tfresources"
+}
+
+mock "report" {
+	module {
+		source = "../../../modules/mocks/report/report.sentinel"
+	}
+}
+
+test {
+  rules = {
+    main = false
+  }
+}

--- a/policies/test/ec2-vpc-default-security-group-no-traffic/failure-security-group-egress-rule-references-default-security-group.hcl
+++ b/policies/test/ec2-vpc-default-security-group-no-traffic/failure-security-group-egress-rule-references-default-security-group.hcl
@@ -1,0 +1,22 @@
+
+mock "tfconfig/v2" {
+  module {
+    source = "./mocks/policy-failure-security-group-egress-rule-references-default-security-group/mock-tfconfig-v2.sentinel"
+  }
+}
+
+import "plugin" "tfresources" {
+	source = "../../../plugins/darwin/arm64/sentinel-plugin-tfresources"
+}
+
+mock "report" {
+	module {
+		source = "../../../modules/mocks/report/report.sentinel"
+	}
+}
+
+test {
+  rules = {
+    main = false
+  }
+}

--- a/policies/test/ec2-vpc-default-security-group-no-traffic/failure-security-group-egress-rule-references-default-vpc-default-sg.hcl
+++ b/policies/test/ec2-vpc-default-security-group-no-traffic/failure-security-group-egress-rule-references-default-vpc-default-sg.hcl
@@ -1,0 +1,22 @@
+
+mock "tfconfig/v2" {
+  module {
+    source = "./mocks/policy-failure-security-group-egress-rule-references-default-vpc-default-sg/mock-tfconfig-v2.sentinel"
+  }
+}
+
+import "plugin" "tfresources" {
+	source = "../../../plugins/darwin/arm64/sentinel-plugin-tfresources"
+}
+
+mock "report" {
+	module {
+		source = "../../../modules/mocks/report/report.sentinel"
+	}
+}
+
+test {
+  rules = {
+    main = false
+  }
+}

--- a/policies/test/ec2-vpc-default-security-group-no-traffic/failure-security-group-egress-rule-references-vpc-default-sg.hcl
+++ b/policies/test/ec2-vpc-default-security-group-no-traffic/failure-security-group-egress-rule-references-vpc-default-sg.hcl
@@ -1,0 +1,22 @@
+
+mock "tfconfig/v2" {
+  module {
+    source = "./mocks/policy-failure-security-group-egress-rule-references-vpc-default-sg/mock-tfconfig-v2.sentinel"
+  }
+}
+
+import "plugin" "tfresources" {
+	source = "../../../plugins/darwin/arm64/sentinel-plugin-tfresources"
+}
+
+mock "report" {
+	module {
+		source = "../../../modules/mocks/report/report.sentinel"
+	}
+}
+
+test {
+  rules = {
+    main = false
+  }
+}

--- a/policies/test/ec2-vpc-default-security-group-no-traffic/failure-security-group-ingress-rule-references-default-security-group.hcl
+++ b/policies/test/ec2-vpc-default-security-group-no-traffic/failure-security-group-ingress-rule-references-default-security-group.hcl
@@ -1,0 +1,22 @@
+
+mock "tfconfig/v2" {
+  module {
+    source = "./mocks/policy-failure-security-group-ingress-rule-references-default-security-group/mock-tfconfig-v2.sentinel"
+  }
+}
+
+import "plugin" "tfresources" {
+	source = "../../../plugins/darwin/arm64/sentinel-plugin-tfresources"
+}
+
+mock "report" {
+	module {
+		source = "../../../modules/mocks/report/report.sentinel"
+	}
+}
+
+test {
+  rules = {
+    main = false
+  }
+}

--- a/policies/test/ec2-vpc-default-security-group-no-traffic/failure-security-group-ingress-rule-references-default-vpc-default-sg.hcl
+++ b/policies/test/ec2-vpc-default-security-group-no-traffic/failure-security-group-ingress-rule-references-default-vpc-default-sg.hcl
@@ -1,0 +1,22 @@
+
+mock "tfconfig/v2" {
+  module {
+    source = "./mocks/policy-failure-security-group-ingress-rule-references-default-vpc-default-sg/mock-tfconfig-v2.sentinel"
+  }
+}
+
+import "plugin" "tfresources" {
+	source = "../../../plugins/darwin/arm64/sentinel-plugin-tfresources"
+}
+
+mock "report" {
+	module {
+		source = "../../../modules/mocks/report/report.sentinel"
+	}
+}
+
+test {
+  rules = {
+    main = false
+  }
+}

--- a/policies/test/ec2-vpc-default-security-group-no-traffic/failure-security-group-ingress-rule-references-vpc-default-sg.hcl
+++ b/policies/test/ec2-vpc-default-security-group-no-traffic/failure-security-group-ingress-rule-references-vpc-default-sg.hcl
@@ -1,0 +1,22 @@
+
+mock "tfconfig/v2" {
+  module {
+    source = "./mocks/policy-failure-security-group-ingress-rule-references-default-vpc-default-sg/mock-tfconfig-v2.sentinel"
+  }
+}
+
+import "plugin" "tfresources" {
+	source = "../../../plugins/darwin/arm64/sentinel-plugin-tfresources"
+}
+
+mock "report" {
+	module {
+		source = "../../../modules/mocks/report/report.sentinel"
+	}
+}
+
+test {
+  rules = {
+    main = false
+  }
+}

--- a/policies/test/ec2-vpc-default-security-group-no-traffic/failure-security-group-rule-references-default-security-group.hcl
+++ b/policies/test/ec2-vpc-default-security-group-no-traffic/failure-security-group-rule-references-default-security-group.hcl
@@ -1,0 +1,22 @@
+
+mock "tfconfig/v2" {
+  module {
+    source = "./mocks/policy-failure-security-group-rule-references-default-security-group/mock-tfconfig-v2.sentinel"
+  }
+}
+
+import "plugin" "tfresources" {
+	source = "../../../plugins/darwin/arm64/sentinel-plugin-tfresources"
+}
+
+mock "report" {
+	module {
+		source = "../../../modules/mocks/report/report.sentinel"
+	}
+}
+
+test {
+  rules = {
+    main = false
+  }
+}

--- a/policies/test/ec2-vpc-default-security-group-no-traffic/failure-security-group-rule-references-default-vpc-default-sg.hcl
+++ b/policies/test/ec2-vpc-default-security-group-no-traffic/failure-security-group-rule-references-default-vpc-default-sg.hcl
@@ -1,0 +1,22 @@
+
+mock "tfconfig/v2" {
+  module {
+    source = "./mocks/policy-failure-security-group-rule-references-vpc-default-sg/mock-tfconfig-v2.sentinel"
+  }
+}
+
+import "plugin" "tfresources" {
+	source = "../../../plugins/darwin/arm64/sentinel-plugin-tfresources"
+}
+
+mock "report" {
+	module {
+		source = "../../../modules/mocks/report/report.sentinel"
+	}
+}
+
+test {
+  rules = {
+    main = false
+  }
+}

--- a/policies/test/ec2-vpc-default-security-group-no-traffic/mocks/policy-failure-default-security-group-with-egress/mock-tfconfig-v2.sentinel
+++ b/policies/test/ec2-vpc-default-security-group-no-traffic/mocks/policy-failure-default-security-group-with-egress/mock-tfconfig-v2.sentinel
@@ -1,0 +1,56 @@
+resources = {
+	"aws_default_security_group.default": {
+		"address": "aws_default_security_group.default",
+		"config": {
+			"egress": {
+				"constant_value": [
+					{
+						"cidr_blocks": [
+							"0.0.0.0/0",
+						],
+						"description":      null,
+						"from_port":        0,
+						"ipv6_cidr_blocks": null,
+						"prefix_list_ids":  null,
+						"protocol":         "-1",
+						"security_groups":  null,
+						"self":             null,
+						"to_port":          0,
+					},
+				],
+			},
+			"vpc_id": {
+				"references": [
+					"aws_vpc.mainvpc.id",
+					"aws_vpc.mainvpc",
+				],
+			},
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "default",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_default_security_group",
+	},
+	"aws_vpc.mainvpc": {
+		"address": "aws_vpc.mainvpc",
+		"config": {
+			"cidr_block": {
+				"constant_value": "10.1.0.0/16",
+			},
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "mainvpc",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_vpc",
+	},
+}

--- a/policies/test/ec2-vpc-default-security-group-no-traffic/mocks/policy-failure-default-security-group-with-ingress/mock-tfconfig-v2.sentinel
+++ b/policies/test/ec2-vpc-default-security-group-no-traffic/mocks/policy-failure-default-security-group-with-ingress/mock-tfconfig-v2.sentinel
@@ -1,0 +1,56 @@
+resources = {
+	"aws_default_security_group.default": {
+		"address": "aws_default_security_group.default",
+		"config": {
+			"ingress": {
+				"constant_value": [
+					{
+						"cidr_blocks": [
+							"0.0.0.0/0",
+						],
+						"description":      null,
+						"from_port":        0,
+						"ipv6_cidr_blocks": null,
+						"prefix_list_ids":  null,
+						"protocol":         "-1",
+						"security_groups":  null,
+						"self":             null,
+						"to_port":          0,
+					},
+				],
+			},
+			"vpc_id": {
+				"references": [
+					"aws_vpc.mainvpc.id",
+					"aws_vpc.mainvpc",
+				],
+			},
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "default",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_default_security_group",
+	},
+	"aws_vpc.mainvpc": {
+		"address": "aws_vpc.mainvpc",
+		"config": {
+			"cidr_block": {
+				"constant_value": "10.1.0.0/16",
+			},
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "mainvpc",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_vpc",
+	},
+}

--- a/policies/test/ec2-vpc-default-security-group-no-traffic/mocks/policy-failure-security-group-egress-rule-references-default-security-group/mock-tfconfig-v2.sentinel
+++ b/policies/test/ec2-vpc-default-security-group-no-traffic/mocks/policy-failure-security-group-egress-rule-references-default-security-group/mock-tfconfig-v2.sentinel
@@ -1,0 +1,67 @@
+resources = {
+	"aws_default_security_group.default": {
+		"address": "aws_default_security_group.default",
+		"config": {
+			"vpc_id": {
+				"references": [
+					"aws_default_vpc.defaultvpc.id",
+					"aws_default_vpc.defaultvpc",
+				],
+			},
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "default",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_default_security_group",
+	},
+	"aws_default_vpc.defaultvpc": {
+		"address":             "aws_default_vpc.defaultvpc",
+		"config":              {},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "defaultvpc",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_default_vpc",
+	},
+	"aws_vpc_security_group_egress_rule.sgr1": {
+		"address": "aws_vpc_security_group_egress_rule.sgr1",
+		"config": {
+			"cidr_ipv4": {
+				"constant_value": "10.0.0.0/8",
+			},
+			"from_port": {
+				"constant_value": 80,
+			},
+			"ip_protocol": {
+				"constant_value": "tcp",
+			},
+			"security_group_id": {
+				"references": [
+					"aws_default_security_group.default.id",
+					"aws_default_security_group.default",
+				],
+			},
+			"to_port": {
+				"constant_value": 80,
+			},
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "sgr1",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_vpc_security_group_egress_rule",
+	},
+}

--- a/policies/test/ec2-vpc-default-security-group-no-traffic/mocks/policy-failure-security-group-egress-rule-references-default-vpc-default-sg/mock-tfconfig-v2.sentinel
+++ b/policies/test/ec2-vpc-default-security-group-no-traffic/mocks/policy-failure-security-group-egress-rule-references-default-vpc-default-sg/mock-tfconfig-v2.sentinel
@@ -1,0 +1,67 @@
+resources = {
+	"aws_default_security_group.default": {
+		"address": "aws_default_security_group.default",
+		"config": {
+			"vpc_id": {
+				"references": [
+					"aws_default_vpc.defaultvpc.id",
+					"aws_default_vpc.defaultvpc",
+				],
+			},
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "default",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_default_security_group",
+	},
+	"aws_default_vpc.defaultvpc": {
+		"address":             "aws_default_vpc.defaultvpc",
+		"config":              {},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "defaultvpc",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_default_vpc",
+	},
+	"aws_vpc_security_group_egress_rule.sgr1": {
+		"address": "aws_vpc_security_group_egress_rule.sgr1",
+		"config": {
+			"cidr_ipv4": {
+				"constant_value": "10.0.0.0/8",
+			},
+			"from_port": {
+				"constant_value": 80,
+			},
+			"ip_protocol": {
+				"constant_value": "tcp",
+			},
+			"security_group_id": {
+				"references": [
+					"aws_default_vpc.defaultvpc.default_security_group_id",
+					"aws_default_vpc.defaultvpc",
+				],
+			},
+			"to_port": {
+				"constant_value": 80,
+			},
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "sgr1",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_vpc_security_group_egress_rule",
+	},
+}

--- a/policies/test/ec2-vpc-default-security-group-no-traffic/mocks/policy-failure-security-group-egress-rule-references-vpc-default-sg/mock-tfconfig-v2.sentinel
+++ b/policies/test/ec2-vpc-default-security-group-no-traffic/mocks/policy-failure-security-group-egress-rule-references-vpc-default-sg/mock-tfconfig-v2.sentinel
@@ -1,0 +1,67 @@
+resources = {
+	"aws_default_security_group.default": {
+		"address": "aws_default_security_group.default",
+		"config": {
+			"vpc_id": {
+				"references": [
+					"aws_vpc.mainvpc.id",
+					"aws_vpc.mainvpc",
+				],
+			},
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "default",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_default_security_group",
+	},
+	"aws_vpc.mainvpc": {
+		"address":             "aws_vpc.mainvpc",
+		"config":              {},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "mainvpc",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_vpc",
+	},
+	"aws_vpc_security_group_egress_rule.sgr1": {
+		"address": "aws_vpc_security_group_egress_rule.sgr1",
+		"config": {
+			"cidr_ipv4": {
+				"constant_value": "10.0.0.0/8",
+			},
+			"from_port": {
+				"constant_value": 80,
+			},
+			"ip_protocol": {
+				"constant_value": "tcp",
+			},
+			"security_group_id": {
+				"references": [
+					"aws_vpc.mainvpc.default_security_group_id",
+					"aws_vpc.mainvpc",
+				],
+			},
+			"to_port": {
+				"constant_value": 80,
+			},
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "sgr1",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_vpc_security_group_egress_rule",
+	},
+}

--- a/policies/test/ec2-vpc-default-security-group-no-traffic/mocks/policy-failure-security-group-ingress-rule-references-default-security-group/mock-tfconfig-v2.sentinel
+++ b/policies/test/ec2-vpc-default-security-group-no-traffic/mocks/policy-failure-security-group-ingress-rule-references-default-security-group/mock-tfconfig-v2.sentinel
@@ -1,0 +1,67 @@
+resources = {
+	"aws_default_security_group.default": {
+		"address": "aws_default_security_group.default",
+		"config": {
+			"vpc_id": {
+				"references": [
+					"aws_default_vpc.defaultvpc.id",
+					"aws_default_vpc.defaultvpc",
+				],
+			},
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "default",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_default_security_group",
+	},
+	"aws_default_vpc.defaultvpc": {
+		"address":             "aws_default_vpc.defaultvpc",
+		"config":              {},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "defaultvpc",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_default_vpc",
+	},
+	"aws_vpc_security_group_ingress_rule.sgr1": {
+		"address": "aws_vpc_security_group_ingress_rule.sgr1",
+		"config": {
+			"cidr_ipv4": {
+				"constant_value": "10.0.0.0/8",
+			},
+			"from_port": {
+				"constant_value": 80,
+			},
+			"ip_protocol": {
+				"constant_value": "tcp",
+			},
+			"security_group_id": {
+				"references": [
+					"aws_default_security_group.default.id",
+					"aws_default_security_group.default",
+				],
+			},
+			"to_port": {
+				"constant_value": 80,
+			},
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "sgr1",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_vpc_security_group_ingress_rule",
+	},
+}

--- a/policies/test/ec2-vpc-default-security-group-no-traffic/mocks/policy-failure-security-group-ingress-rule-references-default-vpc-default-sg/mock-tfconfig-v2.sentinel
+++ b/policies/test/ec2-vpc-default-security-group-no-traffic/mocks/policy-failure-security-group-ingress-rule-references-default-vpc-default-sg/mock-tfconfig-v2.sentinel
@@ -1,0 +1,67 @@
+resources = {
+	"aws_default_security_group.default": {
+		"address": "aws_default_security_group.default",
+		"config": {
+			"vpc_id": {
+				"references": [
+					"aws_default_vpc.defaultvpc.id",
+					"aws_default_vpc.defaultvpc",
+				],
+			},
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "default",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_default_security_group",
+	},
+	"aws_default_vpc.defaultvpc": {
+		"address":             "aws_default_vpc.defaultvpc",
+		"config":              {},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "defaultvpc",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_default_vpc",
+	},
+	"aws_vpc_security_group_ingress_rule.sgr1": {
+		"address": "aws_vpc_security_group_ingress_rule.sgr1",
+		"config": {
+			"cidr_ipv4": {
+				"constant_value": "10.0.0.0/8",
+			},
+			"from_port": {
+				"constant_value": 80,
+			},
+			"ip_protocol": {
+				"constant_value": "tcp",
+			},
+			"security_group_id": {
+				"references": [
+					"aws_default_vpc.defaultvpc.default_security_group_id",
+					"aws_default_vpc.defaultvpc",
+				],
+			},
+			"to_port": {
+				"constant_value": 80,
+			},
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "sgr1",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_vpc_security_group_ingress_rule",
+	},
+}

--- a/policies/test/ec2-vpc-default-security-group-no-traffic/mocks/policy-failure-security-group-ingress-rule-references-vpc-default-sg/mock-tfconfig-v2.sentinel
+++ b/policies/test/ec2-vpc-default-security-group-no-traffic/mocks/policy-failure-security-group-ingress-rule-references-vpc-default-sg/mock-tfconfig-v2.sentinel
@@ -1,0 +1,67 @@
+resources = {
+	"aws_default_security_group.default": {
+		"address": "aws_default_security_group.default",
+		"config": {
+			"vpc_id": {
+				"references": [
+					"aws_vpc.mainvpc.id",
+					"aws_vpc.mainvpc",
+				],
+			},
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "default",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_default_security_group",
+	},
+	"aws_vpc.mainvpc": {
+		"address":             "aws_vpc.mainvpc",
+		"config":              {},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "mainvpc",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_vpc",
+	},
+	"aws_vpc_security_group_ingress_rule.sgr1": {
+		"address": "aws_vpc_security_group_ingress_rule.sgr1",
+		"config": {
+			"cidr_ipv4": {
+				"constant_value": "10.0.0.0/8",
+			},
+			"from_port": {
+				"constant_value": 80,
+			},
+			"ip_protocol": {
+				"constant_value": "tcp",
+			},
+			"security_group_id": {
+				"references": [
+					"aws_vpc.mainvpc.default_security_group_id",
+					"aws_vpc.mainvpc",
+				],
+			},
+			"to_port": {
+				"constant_value": 80,
+			},
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "sgr1",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_vpc_security_group_ingress_rule",
+	},
+}

--- a/policies/test/ec2-vpc-default-security-group-no-traffic/mocks/policy-failure-security-group-rule-references-default-security-group/mock-tfconfig-v2.sentinel
+++ b/policies/test/ec2-vpc-default-security-group-no-traffic/mocks/policy-failure-security-group-rule-references-default-security-group/mock-tfconfig-v2.sentinel
@@ -1,0 +1,81 @@
+resources = {
+	"aws_default_security_group.default": {
+		"address": "aws_default_security_group.default",
+		"config": {
+			"vpc_id": {
+				"references": [
+					"aws_vpc.mainvpc.id",
+					"aws_vpc.mainvpc",
+				],
+			},
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "default",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_default_security_group",
+	},
+	"aws_security_group_rule.sgr1": {
+		"address": "aws_security_group_rule.sgr1",
+		"config": {
+			"cidr_blocks": {
+				"constant_value": [
+					"0.0.0.0/0",
+				],
+			},
+			"from_port": {
+				"constant_value": 22,
+			},
+			"ipv6_cidr_blocks": {
+				"constant_value": [
+					"::/0",
+				],
+			},
+			"protocol": {
+				"constant_value": "ssh",
+			},
+			"security_group_id": {
+				"references": [
+					"aws_default_security_group.default.id",
+					"aws_default_security_group.default",
+				],
+			},
+			"to_port": {
+				"constant_value": 22,
+			},
+			"type": {
+				"constant_value": "ingress",
+			},
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "sgr1",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_security_group_rule",
+	},
+	"aws_vpc.mainvpc": {
+		"address": "aws_vpc.mainvpc",
+		"config": {
+			"cidr_block": {
+				"constant_value": "10.1.0.0/16",
+			},
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "mainvpc",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_vpc",
+	},
+}

--- a/policies/test/ec2-vpc-default-security-group-no-traffic/mocks/policy-failure-security-group-rule-references-default-vpc-default-sg/mock-tfconfig-v2.sentinel
+++ b/policies/test/ec2-vpc-default-security-group-no-traffic/mocks/policy-failure-security-group-rule-references-default-vpc-default-sg/mock-tfconfig-v2.sentinel
@@ -1,0 +1,77 @@
+resources = {
+	"aws_default_security_group.default": {
+		"address": "aws_default_security_group.default",
+		"config": {
+			"vpc_id": {
+				"references": [
+					"aws_default_vpc.defaultvpc.id",
+					"aws_default_vpc.defaultvpc",
+				],
+			},
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "default",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_default_security_group",
+	},
+	"aws_default_vpc.defaultvpc": {
+		"address":             "aws_default_vpc.defaultvpc",
+		"config":              {},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "defaultvpc",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_default_vpc",
+	},
+	"aws_security_group_rule.sgr1": {
+		"address": "aws_security_group_rule.sgr1",
+		"config": {
+			"cidr_blocks": {
+				"constant_value": [
+					"0.0.0.0/0",
+				],
+			},
+			"from_port": {
+				"constant_value": 22,
+			},
+			"ipv6_cidr_blocks": {
+				"constant_value": [
+					"::/0",
+				],
+			},
+			"protocol": {
+				"constant_value": "ssh",
+			},
+			"security_group_id": {
+				"references": [
+					"aws_default_vpc.defaultvpc.default_security_group_id",
+					"aws_default_vpc.defaultvpc",
+				],
+			},
+			"to_port": {
+				"constant_value": 22,
+			},
+			"type": {
+				"constant_value": "ingress",
+			},
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "sgr1",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_security_group_rule",
+	},
+}

--- a/policies/test/ec2-vpc-default-security-group-no-traffic/mocks/policy-failure-security-group-rule-references-vpc-default-sg/mock-tfconfig-v2.sentinel
+++ b/policies/test/ec2-vpc-default-security-group-no-traffic/mocks/policy-failure-security-group-rule-references-vpc-default-sg/mock-tfconfig-v2.sentinel
@@ -1,0 +1,81 @@
+resources = {
+	"aws_default_security_group.default": {
+		"address": "aws_default_security_group.default",
+		"config": {
+			"vpc_id": {
+				"references": [
+					"aws_vpc.mainvpc.id",
+					"aws_vpc.mainvpc",
+				],
+			},
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "default",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_default_security_group",
+	},
+	"aws_security_group_rule.sgr1": {
+		"address": "aws_security_group_rule.sgr1",
+		"config": {
+			"cidr_blocks": {
+				"constant_value": [
+					"0.0.0.0/0",
+				],
+			},
+			"from_port": {
+				"constant_value": 22,
+			},
+			"ipv6_cidr_blocks": {
+				"constant_value": [
+					"::/0",
+				],
+			},
+			"protocol": {
+				"constant_value": "ssh",
+			},
+			"security_group_id": {
+				"references": [
+					"aws_vpc.mainvpc.default_security_group_id",
+					"aws_vpc.mainvpc",
+				],
+			},
+			"to_port": {
+				"constant_value": 22,
+			},
+			"type": {
+				"constant_value": "ingress",
+			},
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "sgr1",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_security_group_rule",
+	},
+	"aws_vpc.mainvpc": {
+		"address": "aws_vpc.mainvpc",
+		"config": {
+			"cidr_block": {
+				"constant_value": "10.1.0.0/16",
+			},
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "mainvpc",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_vpc",
+	},
+}

--- a/policies/test/ec2-vpc-default-security-group-no-traffic/mocks/policy-success-default-security-group-no-traffic/mock-tfconfig-v2.sentinel
+++ b/policies/test/ec2-vpc-default-security-group-no-traffic/mocks/policy-success-default-security-group-no-traffic/mock-tfconfig-v2.sentinel
@@ -1,0 +1,92 @@
+resources = {
+	"aws_security_group.allow_tls": {
+		"address": "aws_security_group.allow_tls",
+		"config": {
+			"description": {
+				"constant_value": "Allow TLS inbound traffic and all outbound traffic",
+			},
+			"name": {
+				"constant_value": "allow_tls",
+			},
+			"tags": {
+				"constant_value": {
+					"Name": "allow_tls",
+				},
+			},
+			"vpc_id": {
+				"references": [
+					"aws_vpc.main.id",
+					"aws_vpc.main",
+				],
+			},
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "allow_tls",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_security_group",
+	},
+	"aws_security_group_rule.sgr1": {
+		"address": "aws_security_group_rule.sgr1",
+		"config": {
+			"cidr_blocks": {
+				"constant_value": [
+					"0.0.0.0/0",
+				],
+			},
+			"from_port": {
+				"constant_value": 22,
+			},
+			"ipv6_cidr_blocks": {
+				"constant_value": [
+					"::/0",
+				],
+			},
+			"protocol": {
+				"constant_value": "ssh",
+			},
+			"security_group_id": {
+				"references": [
+					"aws_security_group.allow_tls.id",
+					"aws_security_group.allow_tls",
+				],
+			},
+			"to_port": {
+				"constant_value": 22,
+			},
+			"type": {
+				"constant_value": "ingress",
+			},
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "sgr1",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_security_group_rule",
+	},
+	"aws_vpc.main": {
+		"address": "aws_vpc.main",
+		"config": {
+			"cidr_block": {
+				"constant_value": "10.1.0.0/16",
+			},
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "main",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_vpc",
+	},
+}

--- a/policies/test/ec2-vpc-default-security-group-no-traffic/success-default-security-group-no-traffic.hcl
+++ b/policies/test/ec2-vpc-default-security-group-no-traffic/success-default-security-group-no-traffic.hcl
@@ -1,0 +1,22 @@
+
+mock "tfconfig/v2" {
+  module {
+    source = "./mocks/policy-success-default-security-group-no-traffic/mock-tfconfig-v2.sentinel"
+  }
+}
+
+import "plugin" "tfresources" {
+	source = "../../../plugins/darwin/arm64/sentinel-plugin-tfresources"
+}
+
+mock "report" {
+	module {
+		source = "../../../modules/mocks/report/report.sentinel"
+	}
+}
+
+test {
+  rules = {
+    main = true
+  }
+}

--- a/sentinel.hcl
+++ b/sentinel.hcl
@@ -973,3 +973,8 @@ policy "kinesis-firehose-delivery-stream-encrypted" {
   source = "./policies/kinesis-firehose-delivery-stream-encrypted.sentinel"
   enforcement_level = "advisory"
 }
+
+policy "ec2-vpc-default-security-group-no-traffic" {
+  source = "./policies/ec2-vpc-default-security-group-no-traffic.sentinel"
+  enforcement_level = "advisory"
+}

--- a/tests/acceptance/ec2-vpc-default-security-group-no-traffic/cases/default-security-groups-with-traffic-rules/.terraform.lock.hcl
+++ b/tests/acceptance/ec2-vpc-default-security-group-no-traffic/cases/default-security-groups-with-traffic-rules/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "5.46.0"
+  hashes = [
+    "h1:d0Mf33mbbQujZ/JaYkqmH5gZGvP+iEIWf9yBSiOwimE=",
+    "zh:05ae6180a7f23071435f6e5e59c19af0b6c5da42ee600c6c1568c8660214d548",
+    "zh:0d878d1565d5e57ce6b34ec5f04b28662044a50c999ec5770c374aa1f1020de2",
+    "zh:25ef1467af2514d8011c44759307445f7057836ff87dfe4503c3e1c9776d5c1a",
+    "zh:26c006df6200f0063b827aab05bec94f9f3f77848e82ed72e48a51d1170d1961",
+    "zh:37cdf4292649a10f12858622826925e18ad4eca354c31f61d02c66895eb91274",
+    "zh:4315b0433c2fc512666c74e989e2d95240934ef370bea1c690d36cb02d30c4ce",
+    "zh:75df0b3f631b78aeff1832cc77d99b527c2a5e79d40f7aac40bdc4a66124dac2",
+    "zh:90693d936c9a556d2bf945de4920ff82052002eb73139bd7164fafd02920f0ef",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:c9177ad09804c60fd2ed25950570407b6bdcdf0fcc309e1673b584f06a827fae",
+    "zh:ca8e8db24a4d62d92afd8d3d383b81a08693acac191a2e0a110fb46deeff56a3",
+    "zh:d5fa3a36e13957d63bfe9bbd6df0426a2422214403aac9f20b60c36f8d9ebec6",
+    "zh:e4ede44a112296c9cc77b15e439e41ee15c0e8b3a0dec94ae34df5ebba840e8b",
+    "zh:f2d4de8d8cde69caffede1544ebea74e69fcc4552e1b79ae053519a05c060706",
+    "zh:fc19e9266b1841d4a3aeefa8a5b5ad6988baed6540f85a373b6c2d0dc1ca5830",
+  ]
+}

--- a/tests/acceptance/ec2-vpc-default-security-group-no-traffic/cases/default-security-groups-with-traffic-rules/backend.tf
+++ b/tests/acceptance/ec2-vpc-default-security-group-no-traffic/cases/default-security-groups-with-traffic-rules/backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  cloud {
+    workspaces {
+      name = "ec2-vpc-default-security-group-no-traffic"
+    }
+  }
+}

--- a/tests/acceptance/ec2-vpc-default-security-group-no-traffic/cases/default-security-groups-with-traffic-rules/main.tf
+++ b/tests/acceptance/ec2-vpc-default-security-group-no-traffic/cases/default-security-groups-with-traffic-rules/main.tf
@@ -1,0 +1,26 @@
+provider "aws" {
+  region = "us-west-2"
+}
+
+resource "aws_vpc" "this" {
+  cidr_block = "10.0.0.0/16"
+}
+
+resource "aws_default_security_group" "this" {
+  vpc_id = aws_vpc.this.id
+
+  ingress {
+    protocol    = -1
+    self        = true
+    from_port   = 0
+    to_port     = 0
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    protocol  = -1
+    self      = true
+    from_port = 0
+    to_port   = 0
+  }
+}

--- a/tests/acceptance/ec2-vpc-default-security-group-no-traffic/cases/non-default-security-group-with-traffic-rules/.terraform.lock.hcl
+++ b/tests/acceptance/ec2-vpc-default-security-group-no-traffic/cases/non-default-security-group-with-traffic-rules/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "5.46.0"
+  hashes = [
+    "h1:d0Mf33mbbQujZ/JaYkqmH5gZGvP+iEIWf9yBSiOwimE=",
+    "zh:05ae6180a7f23071435f6e5e59c19af0b6c5da42ee600c6c1568c8660214d548",
+    "zh:0d878d1565d5e57ce6b34ec5f04b28662044a50c999ec5770c374aa1f1020de2",
+    "zh:25ef1467af2514d8011c44759307445f7057836ff87dfe4503c3e1c9776d5c1a",
+    "zh:26c006df6200f0063b827aab05bec94f9f3f77848e82ed72e48a51d1170d1961",
+    "zh:37cdf4292649a10f12858622826925e18ad4eca354c31f61d02c66895eb91274",
+    "zh:4315b0433c2fc512666c74e989e2d95240934ef370bea1c690d36cb02d30c4ce",
+    "zh:75df0b3f631b78aeff1832cc77d99b527c2a5e79d40f7aac40bdc4a66124dac2",
+    "zh:90693d936c9a556d2bf945de4920ff82052002eb73139bd7164fafd02920f0ef",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:c9177ad09804c60fd2ed25950570407b6bdcdf0fcc309e1673b584f06a827fae",
+    "zh:ca8e8db24a4d62d92afd8d3d383b81a08693acac191a2e0a110fb46deeff56a3",
+    "zh:d5fa3a36e13957d63bfe9bbd6df0426a2422214403aac9f20b60c36f8d9ebec6",
+    "zh:e4ede44a112296c9cc77b15e439e41ee15c0e8b3a0dec94ae34df5ebba840e8b",
+    "zh:f2d4de8d8cde69caffede1544ebea74e69fcc4552e1b79ae053519a05c060706",
+    "zh:fc19e9266b1841d4a3aeefa8a5b5ad6988baed6540f85a373b6c2d0dc1ca5830",
+  ]
+}

--- a/tests/acceptance/ec2-vpc-default-security-group-no-traffic/cases/non-default-security-group-with-traffic-rules/backend.tf
+++ b/tests/acceptance/ec2-vpc-default-security-group-no-traffic/cases/non-default-security-group-with-traffic-rules/backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  cloud {
+    workspaces {
+      name = "ec2-vpc-default-security-group-no-traffic"
+    }
+  }
+}

--- a/tests/acceptance/ec2-vpc-default-security-group-no-traffic/cases/non-default-security-group-with-traffic-rules/main.tf
+++ b/tests/acceptance/ec2-vpc-default-security-group-no-traffic/cases/non-default-security-group-with-traffic-rules/main.tf
@@ -1,0 +1,26 @@
+provider "aws" {
+  region = "us-west-2"
+}
+
+resource "aws_vpc" "this" {
+  cidr_block = "10.0.0.0/16"
+}
+
+resource "aws_security_group" "this" {
+  vpc_id = aws_vpc.this.id
+
+  ingress {
+    protocol    = -1
+    self        = true
+    from_port   = 0
+    to_port     = 0
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    protocol  = -1
+    self      = true
+    from_port = 0
+    to_port   = 0
+  }
+}

--- a/tests/acceptance/ec2-vpc-default-security-group-no-traffic/cases/security-group-rules-referencing-default-security-group/.terraform.lock.hcl
+++ b/tests/acceptance/ec2-vpc-default-security-group-no-traffic/cases/security-group-rules-referencing-default-security-group/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "5.46.0"
+  hashes = [
+    "h1:d0Mf33mbbQujZ/JaYkqmH5gZGvP+iEIWf9yBSiOwimE=",
+    "zh:05ae6180a7f23071435f6e5e59c19af0b6c5da42ee600c6c1568c8660214d548",
+    "zh:0d878d1565d5e57ce6b34ec5f04b28662044a50c999ec5770c374aa1f1020de2",
+    "zh:25ef1467af2514d8011c44759307445f7057836ff87dfe4503c3e1c9776d5c1a",
+    "zh:26c006df6200f0063b827aab05bec94f9f3f77848e82ed72e48a51d1170d1961",
+    "zh:37cdf4292649a10f12858622826925e18ad4eca354c31f61d02c66895eb91274",
+    "zh:4315b0433c2fc512666c74e989e2d95240934ef370bea1c690d36cb02d30c4ce",
+    "zh:75df0b3f631b78aeff1832cc77d99b527c2a5e79d40f7aac40bdc4a66124dac2",
+    "zh:90693d936c9a556d2bf945de4920ff82052002eb73139bd7164fafd02920f0ef",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:c9177ad09804c60fd2ed25950570407b6bdcdf0fcc309e1673b584f06a827fae",
+    "zh:ca8e8db24a4d62d92afd8d3d383b81a08693acac191a2e0a110fb46deeff56a3",
+    "zh:d5fa3a36e13957d63bfe9bbd6df0426a2422214403aac9f20b60c36f8d9ebec6",
+    "zh:e4ede44a112296c9cc77b15e439e41ee15c0e8b3a0dec94ae34df5ebba840e8b",
+    "zh:f2d4de8d8cde69caffede1544ebea74e69fcc4552e1b79ae053519a05c060706",
+    "zh:fc19e9266b1841d4a3aeefa8a5b5ad6988baed6540f85a373b6c2d0dc1ca5830",
+  ]
+}

--- a/tests/acceptance/ec2-vpc-default-security-group-no-traffic/cases/security-group-rules-referencing-default-security-group/backend.tf
+++ b/tests/acceptance/ec2-vpc-default-security-group-no-traffic/cases/security-group-rules-referencing-default-security-group/backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  cloud {
+    workspaces {
+      name = "ec2-vpc-default-security-group-no-traffic"
+    }
+  }
+}

--- a/tests/acceptance/ec2-vpc-default-security-group-no-traffic/cases/security-group-rules-referencing-default-security-group/main.tf
+++ b/tests/acceptance/ec2-vpc-default-security-group-no-traffic/cases/security-group-rules-referencing-default-security-group/main.tf
@@ -1,0 +1,7 @@
+provider "aws" {
+  region = "us-west-2"
+}
+
+module "setup-security-group-rules" {
+  source = "./security-group-rules"
+}

--- a/tests/acceptance/ec2-vpc-default-security-group-no-traffic/cases/security-group-rules-referencing-default-security-group/security-group-rules/main.tf
+++ b/tests/acceptance/ec2-vpc-default-security-group-no-traffic/cases/security-group-rules-referencing-default-security-group/security-group-rules/main.tf
@@ -1,0 +1,40 @@
+resource "aws_vpc" "vpc_one" {
+  cidr_block = "10.1.0.0/16"
+}
+
+resource "aws_vpc" "vpc_two" {
+  cidr_block = "10.2.0.0/16"
+}
+
+resource "aws_default_vpc" "default_vpc" {}
+
+// This rule references the vpc's default security group
+resource "aws_security_group_rule" "rule" {
+  security_group_id = aws_vpc.vpc_one.default_security_group_id
+
+  type        = "ingress"
+  protocol    = -1
+  from_port   = 0
+  to_port     = 0
+  cidr_blocks = ["0.0.0.0/0"]
+}
+
+// This rule references the default vpc's default security group
+resource "aws_vpc_security_group_ingress_rule" "ingress_rule" {
+  security_group_id = aws_default_vpc.default_vpc.default_security_group_id
+
+  ip_protocol = "-1"
+  from_port   = 0
+  to_port     = 0
+  cidr_ipv4   = "0.0.0.0/0"
+}
+
+// This rule references the default vpc's default security group
+resource "aws_vpc_security_group_egress_rule" "egress_rule" {
+  security_group_id = aws_default_vpc.default_vpc.default_security_group_id
+
+  ip_protocol = "-1"
+  from_port   = 0
+  to_port     = 0
+  cidr_ipv4   = "0.0.0.0/0"
+}

--- a/tests/acceptance/ec2-vpc-default-security-group-no-traffic/test-config.hcl
+++ b/tests/acceptance/ec2-vpc-default-security-group-no-traffic/test-config.hcl
@@ -1,0 +1,24 @@
+name = "ec2-vpc-default-security-group-no-traffic"
+
+disabled = false
+
+case "Default security group resource with traffic rules" {
+    path = "cases/default-security-groups-with-traffic-rules"
+    expectation {
+        result = false
+    }
+}
+
+case "Non default security group resource with traffic rules" {
+    path = "cases/non-default-security-group-with-traffic-rules"
+    expectation {
+        result = true
+    }
+}
+
+case "Default security group resources with traffic rules inside nested module" {
+    path = "cases/security-group-rules-referencing-default-security-group"
+    expectation {
+        result = false
+    }
+}


### PR DESCRIPTION
## Changes proposed in this PR:
- Added the ec2-vpc-default-security-group-no-traffic policy
-

## Documentation
- [AWS Standard](https://docs.aws.amazon.com/securityhub/latest/userguide/ec2-controls.html#ec2-2)
- [Policy details](https://docs.aws.amazon.com/securityhub/latest/userguide/ec2-controls.html#ec2-2)

## AWS Provider version

## How I've tested this PR:

## Checklist:
- [x] Tests added