### PR TITLE
Added the ec2-transit-gateway-auto-vpc-attach-disabled policy

### DIFF
--- a/docs/policies/ec2-transit-gateway-auto-vpc-attach-disabled.md
+++ b/docs/policies/ec2-transit-gateway-auto-vpc-attach-disabled.md
@@ -1,0 +1,69 @@
+# Amazon EC2 Transit Gateways should not automatically accept VPC attachment requests
+
+| Provider            |            Category            |
+| ------------------- | ------------------------------ |
+| Amazon Web Services |  Secure Network Configuration  |
+
+## Description
+
+This control checks if EC2 transit gateways are automatically accepting shared VPC attachments. This control fails for a transit gateway that automatically accepts shared VPC attachment requests.
+
+Turning on AutoAcceptSharedAttachments configures a transit gateway to automatically accept any cross-account VPC attachment requests without verifying the request or the account the attachment is originating from. To follow the best practices of authorization and authentication, we recommended turning off this feature to ensure that only authorized VPC attachment requests are accepted.
+
+This rule is covered by the [ec2-transit-gateway-auto-vpc-attach-disabled](../../policies/ec2-transit-gateway-auto-vpc-attach-disabled.sentinel) policy.
+
+## Policy Results (Pass)
+
+```bash
+trace:
+        Pass - ec2-transit-gateway-auto-vpc-attach-disabled.sentinel
+
+        Description:
+        This policy checks if the EC2 Transit Gateway have the attribute
+        'auto_accept_shared_attachments' set to disable
+
+        Print messages:
+
+        → → Overall Result: true
+
+        This result means that all resources have passed the policy check for the policy ec2-transit-gateway-auto-vpc-attach-disabled.
+
+        ✓ Found 0 resource violations
+
+        ec2-transit-gateway-auto-vpc-attach-disabled.sentinel:49:1 - Rule "main"
+        Value:
+            true
+```
+
+---
+
+## Policy Results (Fail)
+
+```bash
+trace:
+        Fail - ec2-transit-gateway-auto-vpc-attach-disabled.sentinel
+
+        Description:
+        This policy checks if the EC2 Transit Gateway have the attribute
+        'auto_accept_shared_attachments' set to disable
+
+        Print messages:
+
+        → → Overall Result: false
+
+        This result means that not all resources passed the policy check and the protected behavior is not allowed for the policy ec2-transit-gateway-auto-vpc-attach-disabled.
+
+        Found 1 resource violations
+
+        → Module name: root
+        ↳ Resource Address: aws_ec2_transit_gateway.example
+            | ✗ failed
+            | Resource EC2 Transit Gateway should have the attribute 'auto_accept_shared_attachments' set to diable. Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/ec2-controls.html#ec2-23 for more details.
+
+
+        ec2-transit-gateway-auto-vpc-attach-disabled.sentinel:49:1 - Rule "main"
+        Value:
+            false
+```
+
+---

--- a/policies/ec2-transit-gateway-auto-vpc-attach-disabled.sentinel
+++ b/policies/ec2-transit-gateway-auto-vpc-attach-disabled.sentinel
@@ -1,0 +1,51 @@
+# This policy checks if the EC2 Transit Gateway have the attribute 'auto_accept_shared_attachments' set to disable
+
+import "tfplan/v2" as tfplan
+import "tfresources" as tf
+import "report" as report
+import "collection" as collection
+import "collection/maps" as maps
+import "json"
+
+# Constants
+const = {
+	"policy_name":                      "ec2-transit-gateway-auto-vpc-attach-disabled",
+	"message":                          "Resource EC2 Transit Gateway should have the attribute 'auto_accept_shared_attachments' set to diable. Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/ec2-controls.html#ec2-23 for more details.",
+	"resource_aws_ec2_transit_gateway": "aws_ec2_transit_gateway",
+	"auto_accept_shared_attachments":   "auto_accept_shared_attachments",
+}
+
+# Functions
+
+get_violations = func(resources) {
+	return collection.reject(resources, func(res) {
+		return maps.get(res, "values.auto_accept_shared_attachments", "disable") is "disable"
+	})
+}
+
+# Variables
+
+ec2_transit_gateway_resources = tf.plan(tfplan.planned_values.resources).type(const.resource_aws_ec2_transit_gateway).resources
+
+violations = get_violations(ec2_transit_gateway_resources)
+
+summary = {
+	"policy_name": const.policy_name,
+	"violations": map violations as _, res {
+		{
+			"address":        res.address,
+			"module_address": res.module_address,
+			"message":        const.message,
+		}
+	},
+}
+
+# Outputs
+
+print(report.generate_policy_report(summary))
+
+# Rules
+
+main = rule {
+	violations is empty
+}

--- a/policies/test/ec2-transit-gateway-auto-vpc-attach-disabled/failure-ec2-transit-gateway-with-auto-accept-shared-attachments-set-to-enable.hcl
+++ b/policies/test/ec2-transit-gateway-auto-vpc-attach-disabled/failure-ec2-transit-gateway-with-auto-accept-shared-attachments-set-to-enable.hcl
@@ -1,0 +1,23 @@
+mock "tfplan/v2" {
+	module {
+		source = "./mocks/policy-failure-ec2-transit-gateway-with-auto-accept-shared-attachments-set-to-enable/mock-tfplan-v2.sentinel"
+	}
+}
+
+
+
+import "plugin" "tfresources" {
+	source = "../../../plugins/darwin/arm64/sentinel-plugin-tfresources"
+}
+
+mock "report" {
+	module {
+		source = "../../../modules/mocks/report/report.sentinel"
+	}
+}
+
+test {
+	rules = {
+		main = false
+	}
+}

--- a/policies/test/ec2-transit-gateway-auto-vpc-attach-disabled/mocks/policy-failure-ec2-transit-gateway-with-auto-accept-shared-attachments-set-to-enable/mock-tfplan-v2.sentinel
+++ b/policies/test/ec2-transit-gateway-auto-vpc-attach-disabled/mocks/policy-failure-ec2-transit-gateway-with-auto-accept-shared-attachments-set-to-enable/mock-tfplan-v2.sentinel
@@ -1,0 +1,192 @@
+terraform_version = "1.9.4"
+
+planned_values = {
+	"outputs": {},
+	"resources": {
+		"aws_ec2_transit_gateway.example": {
+			"address":        "aws_ec2_transit_gateway.example",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "example",
+			"provider_name":  "registry.terraform.io/hashicorp/aws",
+			"tainted":        false,
+			"type":           "aws_ec2_transit_gateway",
+			"values": {
+				"amazon_side_asn":                    64512,
+				"auto_accept_shared_attachments":     "enable",
+				"default_route_table_association":    "enable",
+				"default_route_table_propagation":    "enable",
+				"description":                        "example",
+				"dns_support":                        "enable",
+				"multicast_support":                  "disable",
+				"security_group_referencing_support": "disable",
+				"tags":                        null,
+				"timeouts":                    null,
+				"transit_gateway_cidr_blocks": null,
+				"vpn_ecmp_support":            "enable",
+			},
+		},
+	},
+}
+
+variables = {}
+
+resource_changes = {
+	"aws_ec2_transit_gateway.example": {
+		"address": "aws_ec2_transit_gateway.example",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"amazon_side_asn":                    64512,
+				"auto_accept_shared_attachments":     "enable",
+				"default_route_table_association":    "enable",
+				"default_route_table_propagation":    "enable",
+				"description":                        "example",
+				"dns_support":                        "enable",
+				"multicast_support":                  "disable",
+				"security_group_referencing_support": "disable",
+				"tags":                        null,
+				"timeouts":                    null,
+				"transit_gateway_cidr_blocks": null,
+				"vpn_ecmp_support":            "enable",
+			},
+			"after_unknown": {
+				"arn": true,
+				"association_default_route_table_id": true,
+				"id":                                 true,
+				"owner_id":                           true,
+				"propagation_default_route_table_id": true,
+				"tags_all":                           true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "example",
+		"provider_name":  "registry.terraform.io/hashicorp/aws",
+		"type":           "aws_ec2_transit_gateway",
+	},
+}
+
+resource_drift = {}
+
+output_changes = {}
+
+raw = {
+	"complete": true,
+	"configuration": {
+		"provider_config": {
+			"aws": {
+				"expressions": {
+					"region": {
+						"constant_value": "us-east-1",
+					},
+				},
+				"full_name": "registry.terraform.io/hashicorp/aws",
+				"name":      "aws",
+			},
+		},
+		"root_module": {
+			"resources": [
+				{
+					"address": "aws_ec2_transit_gateway.example",
+					"expressions": {
+						"auto_accept_shared_attachments": {
+							"constant_value": "enable",
+						},
+						"description": {
+							"constant_value": "example",
+						},
+					},
+					"mode":                "managed",
+					"name":                "example",
+					"provider_config_key": "aws",
+					"schema_version":      0,
+					"type":                "aws_ec2_transit_gateway",
+				},
+			],
+		},
+	},
+	"format_version": "1.2",
+	"planned_values": {
+		"root_module": {
+			"resources": [
+				{
+					"address":        "aws_ec2_transit_gateway.example",
+					"mode":           "managed",
+					"name":           "example",
+					"provider_name":  "registry.terraform.io/hashicorp/aws",
+					"schema_version": 0,
+					"sensitive_values": {
+						"tags_all": {},
+					},
+					"type": "aws_ec2_transit_gateway",
+					"values": {
+						"amazon_side_asn":                    64512,
+						"auto_accept_shared_attachments":     "enable",
+						"default_route_table_association":    "enable",
+						"default_route_table_propagation":    "enable",
+						"description":                        "example",
+						"dns_support":                        "enable",
+						"multicast_support":                  "disable",
+						"security_group_referencing_support": "disable",
+						"tags":                        null,
+						"timeouts":                    null,
+						"transit_gateway_cidr_blocks": null,
+						"vpn_ecmp_support":            "enable",
+					},
+				},
+			],
+		},
+	},
+	"resource_changes": [
+		{
+			"address": "aws_ec2_transit_gateway.example",
+			"change": {
+				"actions": [
+					"create",
+				],
+				"after": {
+					"amazon_side_asn":                    64512,
+					"auto_accept_shared_attachments":     "enable",
+					"default_route_table_association":    "enable",
+					"default_route_table_propagation":    "enable",
+					"description":                        "example",
+					"dns_support":                        "enable",
+					"multicast_support":                  "disable",
+					"security_group_referencing_support": "disable",
+					"tags":                        null,
+					"timeouts":                    null,
+					"transit_gateway_cidr_blocks": null,
+					"vpn_ecmp_support":            "enable",
+				},
+				"after_sensitive": {
+					"tags_all": {},
+				},
+				"after_unknown": {
+					"arn": true,
+					"association_default_route_table_id": true,
+					"id":                                 true,
+					"owner_id":                           true,
+					"propagation_default_route_table_id": true,
+					"tags_all":                           true,
+				},
+				"before":           null,
+				"before_sensitive": false,
+			},
+			"mode":          "managed",
+			"name":          "example",
+			"provider_name": "registry.terraform.io/hashicorp/aws",
+			"type":          "aws_ec2_transit_gateway",
+		},
+	],
+	"terraform_version": "1.9.4",
+	"timestamp":         "2025-04-04T06:36:02Z",
+}

--- a/policies/test/ec2-transit-gateway-auto-vpc-attach-disabled/mocks/policy-success-ec2-transit-gateway-with-auto-accept-shared-attachments-attribute-not-present/mock-tfplan-v2.sentinel
+++ b/policies/test/ec2-transit-gateway-auto-vpc-attach-disabled/mocks/policy-success-ec2-transit-gateway-with-auto-accept-shared-attachments-attribute-not-present/mock-tfplan-v2.sentinel
@@ -1,0 +1,189 @@
+terraform_version = "1.9.4"
+
+planned_values = {
+	"outputs": {},
+	"resources": {
+		"aws_ec2_transit_gateway.example": {
+			"address":        "aws_ec2_transit_gateway.example",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "example",
+			"provider_name":  "registry.terraform.io/hashicorp/aws",
+			"tainted":        false,
+			"type":           "aws_ec2_transit_gateway",
+			"values": {
+				"amazon_side_asn":                    64512,
+				"auto_accept_shared_attachments":     "disable",
+				"default_route_table_association":    "enable",
+				"default_route_table_propagation":    "enable",
+				"description":                        "example",
+				"dns_support":                        "enable",
+				"multicast_support":                  "disable",
+				"security_group_referencing_support": "disable",
+				"tags":                        null,
+				"timeouts":                    null,
+				"transit_gateway_cidr_blocks": null,
+				"vpn_ecmp_support":            "enable",
+			},
+		},
+	},
+}
+
+variables = {}
+
+resource_changes = {
+	"aws_ec2_transit_gateway.example": {
+		"address": "aws_ec2_transit_gateway.example",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"amazon_side_asn":                    64512,
+				"auto_accept_shared_attachments":     "disable",
+				"default_route_table_association":    "enable",
+				"default_route_table_propagation":    "enable",
+				"description":                        "example",
+				"dns_support":                        "enable",
+				"multicast_support":                  "disable",
+				"security_group_referencing_support": "disable",
+				"tags":                        null,
+				"timeouts":                    null,
+				"transit_gateway_cidr_blocks": null,
+				"vpn_ecmp_support":            "enable",
+			},
+			"after_unknown": {
+				"arn": true,
+				"association_default_route_table_id": true,
+				"id":                                 true,
+				"owner_id":                           true,
+				"propagation_default_route_table_id": true,
+				"tags_all":                           true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "example",
+		"provider_name":  "registry.terraform.io/hashicorp/aws",
+		"type":           "aws_ec2_transit_gateway",
+	},
+}
+
+resource_drift = {}
+
+output_changes = {}
+
+raw = {
+	"complete": true,
+	"configuration": {
+		"provider_config": {
+			"aws": {
+				"expressions": {
+					"region": {
+						"constant_value": "us-east-1",
+					},
+				},
+				"full_name": "registry.terraform.io/hashicorp/aws",
+				"name":      "aws",
+			},
+		},
+		"root_module": {
+			"resources": [
+				{
+					"address": "aws_ec2_transit_gateway.example",
+					"expressions": {
+						"description": {
+							"constant_value": "example",
+						},
+					},
+					"mode":                "managed",
+					"name":                "example",
+					"provider_config_key": "aws",
+					"schema_version":      0,
+					"type":                "aws_ec2_transit_gateway",
+				},
+			],
+		},
+	},
+	"format_version": "1.2",
+	"planned_values": {
+		"root_module": {
+			"resources": [
+				{
+					"address":        "aws_ec2_transit_gateway.example",
+					"mode":           "managed",
+					"name":           "example",
+					"provider_name":  "registry.terraform.io/hashicorp/aws",
+					"schema_version": 0,
+					"sensitive_values": {
+						"tags_all": {},
+					},
+					"type": "aws_ec2_transit_gateway",
+					"values": {
+						"amazon_side_asn":                    64512,
+						"auto_accept_shared_attachments":     "disable",
+						"default_route_table_association":    "enable",
+						"default_route_table_propagation":    "enable",
+						"description":                        "example",
+						"dns_support":                        "enable",
+						"multicast_support":                  "disable",
+						"security_group_referencing_support": "disable",
+						"tags":                        null,
+						"timeouts":                    null,
+						"transit_gateway_cidr_blocks": null,
+						"vpn_ecmp_support":            "enable",
+					},
+				},
+			],
+		},
+	},
+	"resource_changes": [
+		{
+			"address": "aws_ec2_transit_gateway.example",
+			"change": {
+				"actions": [
+					"create",
+				],
+				"after": {
+					"amazon_side_asn":                    64512,
+					"auto_accept_shared_attachments":     "disable",
+					"default_route_table_association":    "enable",
+					"default_route_table_propagation":    "enable",
+					"description":                        "example",
+					"dns_support":                        "enable",
+					"multicast_support":                  "disable",
+					"security_group_referencing_support": "disable",
+					"tags":                        null,
+					"timeouts":                    null,
+					"transit_gateway_cidr_blocks": null,
+					"vpn_ecmp_support":            "enable",
+				},
+				"after_sensitive": {
+					"tags_all": {},
+				},
+				"after_unknown": {
+					"arn": true,
+					"association_default_route_table_id": true,
+					"id":                                 true,
+					"owner_id":                           true,
+					"propagation_default_route_table_id": true,
+					"tags_all":                           true,
+				},
+				"before":           null,
+				"before_sensitive": false,
+			},
+			"mode":          "managed",
+			"name":          "example",
+			"provider_name": "registry.terraform.io/hashicorp/aws",
+			"type":          "aws_ec2_transit_gateway",
+		},
+	],
+	"terraform_version": "1.9.4",
+	"timestamp":         "2025-04-04T06:35:27Z",
+}

--- a/policies/test/ec2-transit-gateway-auto-vpc-attach-disabled/mocks/policy-success-ec2-transit-gateway-with-auto-accept-shared-attachments-to-disabled/mock-tfplan-v2.sentinel
+++ b/policies/test/ec2-transit-gateway-auto-vpc-attach-disabled/mocks/policy-success-ec2-transit-gateway-with-auto-accept-shared-attachments-to-disabled/mock-tfplan-v2.sentinel
@@ -1,0 +1,192 @@
+terraform_version = "1.9.4"
+
+planned_values = {
+	"outputs": {},
+	"resources": {
+		"aws_ec2_transit_gateway.example": {
+			"address":        "aws_ec2_transit_gateway.example",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "example",
+			"provider_name":  "registry.terraform.io/hashicorp/aws",
+			"tainted":        false,
+			"type":           "aws_ec2_transit_gateway",
+			"values": {
+				"amazon_side_asn":                    64512,
+				"auto_accept_shared_attachments":     "disable",
+				"default_route_table_association":    "enable",
+				"default_route_table_propagation":    "enable",
+				"description":                        "example",
+				"dns_support":                        "enable",
+				"multicast_support":                  "disable",
+				"security_group_referencing_support": "disable",
+				"tags":                        null,
+				"timeouts":                    null,
+				"transit_gateway_cidr_blocks": null,
+				"vpn_ecmp_support":            "enable",
+			},
+		},
+	},
+}
+
+variables = {}
+
+resource_changes = {
+	"aws_ec2_transit_gateway.example": {
+		"address": "aws_ec2_transit_gateway.example",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"amazon_side_asn":                    64512,
+				"auto_accept_shared_attachments":     "disable",
+				"default_route_table_association":    "enable",
+				"default_route_table_propagation":    "enable",
+				"description":                        "example",
+				"dns_support":                        "enable",
+				"multicast_support":                  "disable",
+				"security_group_referencing_support": "disable",
+				"tags":                        null,
+				"timeouts":                    null,
+				"transit_gateway_cidr_blocks": null,
+				"vpn_ecmp_support":            "enable",
+			},
+			"after_unknown": {
+				"arn": true,
+				"association_default_route_table_id": true,
+				"id":                                 true,
+				"owner_id":                           true,
+				"propagation_default_route_table_id": true,
+				"tags_all":                           true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "example",
+		"provider_name":  "registry.terraform.io/hashicorp/aws",
+		"type":           "aws_ec2_transit_gateway",
+	},
+}
+
+resource_drift = {}
+
+output_changes = {}
+
+raw = {
+	"complete": true,
+	"configuration": {
+		"provider_config": {
+			"aws": {
+				"expressions": {
+					"region": {
+						"constant_value": "us-east-1",
+					},
+				},
+				"full_name": "registry.terraform.io/hashicorp/aws",
+				"name":      "aws",
+			},
+		},
+		"root_module": {
+			"resources": [
+				{
+					"address": "aws_ec2_transit_gateway.example",
+					"expressions": {
+						"auto_accept_shared_attachments": {
+							"constant_value": "disable",
+						},
+						"description": {
+							"constant_value": "example",
+						},
+					},
+					"mode":                "managed",
+					"name":                "example",
+					"provider_config_key": "aws",
+					"schema_version":      0,
+					"type":                "aws_ec2_transit_gateway",
+				},
+			],
+		},
+	},
+	"format_version": "1.2",
+	"planned_values": {
+		"root_module": {
+			"resources": [
+				{
+					"address":        "aws_ec2_transit_gateway.example",
+					"mode":           "managed",
+					"name":           "example",
+					"provider_name":  "registry.terraform.io/hashicorp/aws",
+					"schema_version": 0,
+					"sensitive_values": {
+						"tags_all": {},
+					},
+					"type": "aws_ec2_transit_gateway",
+					"values": {
+						"amazon_side_asn":                    64512,
+						"auto_accept_shared_attachments":     "disable",
+						"default_route_table_association":    "enable",
+						"default_route_table_propagation":    "enable",
+						"description":                        "example",
+						"dns_support":                        "enable",
+						"multicast_support":                  "disable",
+						"security_group_referencing_support": "disable",
+						"tags":                        null,
+						"timeouts":                    null,
+						"transit_gateway_cidr_blocks": null,
+						"vpn_ecmp_support":            "enable",
+					},
+				},
+			],
+		},
+	},
+	"resource_changes": [
+		{
+			"address": "aws_ec2_transit_gateway.example",
+			"change": {
+				"actions": [
+					"create",
+				],
+				"after": {
+					"amazon_side_asn":                    64512,
+					"auto_accept_shared_attachments":     "disable",
+					"default_route_table_association":    "enable",
+					"default_route_table_propagation":    "enable",
+					"description":                        "example",
+					"dns_support":                        "enable",
+					"multicast_support":                  "disable",
+					"security_group_referencing_support": "disable",
+					"tags":                        null,
+					"timeouts":                    null,
+					"transit_gateway_cidr_blocks": null,
+					"vpn_ecmp_support":            "enable",
+				},
+				"after_sensitive": {
+					"tags_all": {},
+				},
+				"after_unknown": {
+					"arn": true,
+					"association_default_route_table_id": true,
+					"id":                                 true,
+					"owner_id":                           true,
+					"propagation_default_route_table_id": true,
+					"tags_all":                           true,
+				},
+				"before":           null,
+				"before_sensitive": false,
+			},
+			"mode":          "managed",
+			"name":          "example",
+			"provider_name": "registry.terraform.io/hashicorp/aws",
+			"type":          "aws_ec2_transit_gateway",
+		},
+	],
+	"terraform_version": "1.9.4",
+	"timestamp":         "2025-04-04T06:34:57Z",
+}

--- a/policies/test/ec2-transit-gateway-auto-vpc-attach-disabled/success-ec2-transit-gateway-with-auto-accept-shared-attachments-attribute-not-present.hcl
+++ b/policies/test/ec2-transit-gateway-auto-vpc-attach-disabled/success-ec2-transit-gateway-with-auto-accept-shared-attachments-attribute-not-present.hcl
@@ -1,0 +1,23 @@
+mock "tfplan/v2" {
+	module {
+		source = "./mocks/policy-success-ec2-transit-gateway-with-auto-accept-shared-attachments-attribute-not-present/mock-tfplan-v2.sentinel"
+	}
+}
+
+
+
+import "plugin" "tfresources" {
+	source = "../../../plugins/darwin/arm64/sentinel-plugin-tfresources"
+}
+
+mock "report" {
+	module {
+		source = "../../../modules/mocks/report/report.sentinel"
+	}
+}
+
+test {
+	rules = {
+		main = true
+	}
+}

--- a/policies/test/ec2-transit-gateway-auto-vpc-attach-disabled/success-ec2-transit-gateway-with-auto-accept-shared-attachments-to-disabled.hcl
+++ b/policies/test/ec2-transit-gateway-auto-vpc-attach-disabled/success-ec2-transit-gateway-with-auto-accept-shared-attachments-to-disabled.hcl
@@ -1,0 +1,23 @@
+mock "tfplan/v2" {
+	module {
+		source = "./mocks/policy-success-ec2-transit-gateway-with-auto-accept-shared-attachments-to-disabled/mock-tfplan-v2.sentinel"
+	}
+}
+
+
+
+import "plugin" "tfresources" {
+	source = "../../../plugins/darwin/arm64/sentinel-plugin-tfresources"
+}
+
+mock "report" {
+	module {
+		source = "../../../modules/mocks/report/report.sentinel"
+	}
+}
+
+test {
+	rules = {
+		main = true
+	}
+}

--- a/sentinel.hcl
+++ b/sentinel.hcl
@@ -973,3 +973,8 @@ policy "kinesis-firehose-delivery-stream-encrypted" {
   source = "./policies/kinesis-firehose-delivery-stream-encrypted.sentinel"
   enforcement_level = "advisory"
 }
+
+policy "ec2-transit-gateway-auto-vpc-attach-disabled" {
+  source = "./policies/ec2-transit-gateway-auto-vpc-attach-disabled.sentinel"
+  enforcement_level = "advisory"
+}

--- a/tests/acceptance/ec2-transit-gateway-auto-vpc-attach-disabled/cases/ec2-transit-gateway-with-auto-accept-shared-attachments-attribute-not-present/backend.tf
+++ b/tests/acceptance/ec2-transit-gateway-auto-vpc-attach-disabled/cases/ec2-transit-gateway-with-auto-accept-shared-attachments-attribute-not-present/backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  cloud {
+    workspaces {
+      name = "ec2-transit-gateway-auto-vpc-attach-disabled"
+    }
+  }
+}

--- a/tests/acceptance/ec2-transit-gateway-auto-vpc-attach-disabled/cases/ec2-transit-gateway-with-auto-accept-shared-attachments-attribute-not-present/main.tf
+++ b/tests/acceptance/ec2-transit-gateway-auto-vpc-attach-disabled/cases/ec2-transit-gateway-with-auto-accept-shared-attachments-attribute-not-present/main.tf
@@ -1,0 +1,7 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+resource "aws_ec2_transit_gateway" "example" {
+  description = "example"
+}

--- a/tests/acceptance/ec2-transit-gateway-auto-vpc-attach-disabled/cases/ec2-transit-gateway-with-auto-accept-shared-attachments-set-to-disable/backend.tf
+++ b/tests/acceptance/ec2-transit-gateway-auto-vpc-attach-disabled/cases/ec2-transit-gateway-with-auto-accept-shared-attachments-set-to-disable/backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  cloud {
+    workspaces {
+      name = "ec2-transit-gateway-auto-vpc-attach-disabled"
+    }
+  }
+}

--- a/tests/acceptance/ec2-transit-gateway-auto-vpc-attach-disabled/cases/ec2-transit-gateway-with-auto-accept-shared-attachments-set-to-disable/main.tf
+++ b/tests/acceptance/ec2-transit-gateway-auto-vpc-attach-disabled/cases/ec2-transit-gateway-with-auto-accept-shared-attachments-set-to-disable/main.tf
@@ -1,0 +1,8 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+resource "aws_ec2_transit_gateway" "example" {
+  description                    = "example"
+  auto_accept_shared_attachments = "disable"
+}

--- a/tests/acceptance/ec2-transit-gateway-auto-vpc-attach-disabled/cases/ec2-transit-gateway-with-auto-accept-shared-attachments-set-to-enable/backend.tf
+++ b/tests/acceptance/ec2-transit-gateway-auto-vpc-attach-disabled/cases/ec2-transit-gateway-with-auto-accept-shared-attachments-set-to-enable/backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  cloud {
+    workspaces {
+      name = "ec2-transit-gateway-auto-vpc-attach-disabled"
+    }
+  }
+}

--- a/tests/acceptance/ec2-transit-gateway-auto-vpc-attach-disabled/cases/ec2-transit-gateway-with-auto-accept-shared-attachments-set-to-enable/main.tf
+++ b/tests/acceptance/ec2-transit-gateway-auto-vpc-attach-disabled/cases/ec2-transit-gateway-with-auto-accept-shared-attachments-set-to-enable/main.tf
@@ -1,0 +1,8 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+resource "aws_ec2_transit_gateway" "example" {
+  description                    = "example"
+  auto_accept_shared_attachments = "enable"
+}

--- a/tests/acceptance/ec2-transit-gateway-auto-vpc-attach-disabled/test-config.hcl
+++ b/tests/acceptance/ec2-transit-gateway-auto-vpc-attach-disabled/test-config.hcl
@@ -1,0 +1,24 @@
+name = "ec2-transit-gateway-auto-vpc-attach-disabled"
+	
+disabled = false
+
+case "ec2-transit-gateway-with-auto-accept-shared-attachments-set-to-enable" {
+	path = "./cases/ec2-transit-gateway-with-auto-accept-shared-attachments-set-to-enable"
+	expectation {
+		result = false
+	}
+}
+
+case "ec2-transit-gateway-with-auto-accept-shared-attachments-set-to-disable" {
+	path = "./cases/ec2-transit-gateway-with-auto-accept-shared-attachments-set-to-disable"
+	expectation {
+		result = true
+	}
+}
+
+case "ec2-transit-gateway-with-auto-accept-shared-attachments-attribute-not-present" {
+	path = "./cases/ec2-transit-gateway-with-auto-accept-shared-attachments-attribute-not-present"
+	expectation {
+		result = true
+	}
+}


### PR DESCRIPTION
## Changes proposed in this PR:
- Added the ec2-transit-gateway-auto-vpc-attach-disabled policy

## Documentation
- [AWS Standard](https://docs.aws.amazon.com/securityhub/latest/userguide/ec2-controls.html#ec2-23)
- [Policy details](https://docs.aws.amazon.com/securityhub/latest/userguide/ec2-controls.html#ec2-23)

## AWS Provider version

## How I've tested this PR:

## Checklist:
- [x] Tests added