### PR TITLE
Added waf-global-rulegroup-not-empty

### DIFF
--- a/docs/policies/waf-global-rulegroup-not-empty.md
+++ b/docs/policies/waf-global-rulegroup-not-empty.md
@@ -1,0 +1,67 @@
+# AWS WAF Classic global rule groups should have at least one rule
+
+| Provider            | Category                     |
+|---------------------|------------------------------|
+| Amazon Web Services | Secure network configuration |
+
+## Description
+
+This control checks whether an AWS WAF global rule group has at least one rule. The control fails if no rules are present within a rule group.
+
+A WAF global rule group can contain multiple rules. The rule's conditions allow for traffic inspection and take a defined action (allow, block, or count). Without any rules, the traffic passes without inspection. A WAF global rule group with no rules, but with a name or tag suggesting allow, block, or count, could lead to the wrong assumption that one of those actions is occurring.
+
+This rule is covered by the [waf-global-rulegroup-not-empty](../../policies/waf-global-rulegroup-not-empty.sentinel) policy.
+
+## Policy Results (Pass)
+```bash
+trace:
+      Pass - waf-global-rulegroup-not-empty.sentinel
+
+      Description:
+        This policy requires resources of type `aws_waf_rule_group` to have at least
+        one rule.
+
+      Print messages:
+
+      → → Overall Result: true
+
+      This result means that all resources have passed the policy check for the policy waf-global-rulegroup-not-empty.
+
+      ✓ Found 0 resource violations
+
+      waf-global-rulegroup-not-empty.sentinel:44:1 - Rule "main"
+        Value:
+          true
+```
+
+---
+
+## Policy Results (Fail)
+```bash
+trace:
+      Fail - waf-global-rulegroup-not-empty.sentinel
+
+      Description:
+        This policy requires resources of type `aws_waf_rule_group` to have at least
+        one rule.
+
+      Print messages:
+
+      → → Overall Result: false
+
+      This result means that not all resources passed the policy check and the protected behavior is not allowed for the policy waf-global-rulegroup-not-empty.
+
+      Found 1 resource violations
+
+      → Module name: root
+        ↳ Resource Address: aws_waf_rule_group.example
+          | ✗ failed
+          | AWS WAF Classic global rule groups should have at least one rule. Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/waf-controls.html#waf-7 for more details.
+
+
+      waf-global-rulegroup-not-empty.sentinel:44:1 - Rule "main"
+        Value:
+          false
+```
+
+---

--- a/policies/test/waf-global-rulegroup-not-empty/failure-rules-are-empty.hcl
+++ b/policies/test/waf-global-rulegroup-not-empty/failure-rules-are-empty.hcl
@@ -1,0 +1,23 @@
+mock "tfplan/v2" {
+	module {
+		source = "./mocks/policy-failure-rules-are-empty/mock-tfplan-v2.sentinel"
+	}
+}
+
+
+
+import "plugin" "tfresources" {
+	source = "../../../plugins/darwin/arm64/sentinel-plugin-tfresources"
+}
+
+mock "report" {
+	module {
+		source = "../../../modules/mocks/report/report.sentinel"
+	}
+}
+
+test {
+	rules = {
+		main = false
+	}
+}

--- a/policies/test/waf-global-rulegroup-not-empty/mocks/policy-failure-rules-are-empty/mock-tfplan-v2.sentinel
+++ b/policies/test/waf-global-rulegroup-not-empty/mocks/policy-failure-rules-are-empty/mock-tfplan-v2.sentinel
@@ -1,0 +1,158 @@
+terraform_version = "1.10.2"
+
+planned_values = {
+	"outputs": {},
+	"resources": {
+		"aws_waf_rule_group.example": {
+			"address":        "aws_waf_rule_group.example",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "example",
+			"provider_name":  "registry.terraform.io/hashicorp/aws",
+			"tainted":        false,
+			"type":           "aws_waf_rule_group",
+			"values": {
+				"activated_rule": [],
+				"metric_name":    "example",
+				"name":           "example",
+				"tags":           null,
+			},
+		},
+	},
+}
+
+variables = {}
+
+resource_changes = {
+	"aws_waf_rule_group.example": {
+		"address": "aws_waf_rule_group.example",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"activated_rule": [],
+				"metric_name":    "example",
+				"name":           "example",
+				"tags":           null,
+			},
+			"after_unknown": {
+				"activated_rule": [],
+				"arn":            true,
+				"id":             true,
+				"tags_all":       true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "example",
+		"provider_name":  "registry.terraform.io/hashicorp/aws",
+		"type":           "aws_waf_rule_group",
+	},
+}
+
+resource_drift = {}
+
+output_changes = {}
+
+raw = {
+	"complete": true,
+	"configuration": {
+		"provider_config": {
+			"aws": {
+				"expressions": {
+					"region": {
+						"constant_value": "us-east-1",
+					},
+				},
+				"full_name": "registry.terraform.io/hashicorp/aws",
+				"name":      "aws",
+			},
+		},
+		"root_module": {
+			"resources": [
+				{
+					"address": "aws_waf_rule_group.example",
+					"expressions": {
+						"metric_name": {
+							"constant_value": "example",
+						},
+						"name": {
+							"constant_value": "example",
+						},
+					},
+					"mode":                "managed",
+					"name":                "example",
+					"provider_config_key": "aws",
+					"schema_version":      0,
+					"type":                "aws_waf_rule_group",
+				},
+			],
+		},
+	},
+	"format_version": "1.2",
+	"planned_values": {
+		"root_module": {
+			"resources": [
+				{
+					"address":        "aws_waf_rule_group.example",
+					"mode":           "managed",
+					"name":           "example",
+					"provider_name":  "registry.terraform.io/hashicorp/aws",
+					"schema_version": 0,
+					"sensitive_values": {
+						"activated_rule": [],
+						"tags_all":       {},
+					},
+					"type": "aws_waf_rule_group",
+					"values": {
+						"activated_rule": [],
+						"metric_name":    "example",
+						"name":           "example",
+						"tags":           null,
+					},
+				},
+			],
+		},
+	},
+	"resource_changes": [
+		{
+			"address": "aws_waf_rule_group.example",
+			"change": {
+				"actions": [
+					"create",
+				],
+				"after": {
+					"activated_rule": [],
+					"metric_name":    "example",
+					"name":           "example",
+					"tags":           null,
+				},
+				"after_sensitive": {
+					"activated_rule": [],
+					"tags_all":       {},
+				},
+				"after_unknown": {
+					"activated_rule": [],
+					"arn":            true,
+					"id":             true,
+					"tags_all":       true,
+				},
+				"before":           null,
+				"before_sensitive": false,
+			},
+			"mode":          "managed",
+			"name":          "example",
+			"provider_name": "registry.terraform.io/hashicorp/aws",
+			"type":          "aws_waf_rule_group",
+		},
+	],
+	"terraform_version": "1.10.2",
+	"timestamp":         "2025-04-07T20:02:49Z",
+}

--- a/policies/test/waf-global-rulegroup-not-empty/mocks/policy-success-rules-are-not-empty/mock-tfplan-v2.sentinel
+++ b/policies/test/waf-global-rulegroup-not-empty/mocks/policy-success-rules-are-not-empty/mock-tfplan-v2.sentinel
@@ -1,0 +1,362 @@
+terraform_version = "1.10.2"
+
+planned_values = {
+	"outputs": {},
+	"resources": {
+		"aws_waf_rule.example": {
+			"address":        "aws_waf_rule.example",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "example",
+			"provider_name":  "registry.terraform.io/hashicorp/aws",
+			"tainted":        false,
+			"type":           "aws_waf_rule",
+			"values": {
+				"metric_name": "example",
+				"name":        "example",
+				"predicates":  [],
+				"tags":        null,
+			},
+		},
+		"aws_waf_rule_group.example": {
+			"address":        "aws_waf_rule_group.example",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "example",
+			"provider_name":  "registry.terraform.io/hashicorp/aws",
+			"tainted":        false,
+			"type":           "aws_waf_rule_group",
+			"values": {
+				"activated_rule": [
+					{
+						"action": [
+							{
+								"type": "COUNT",
+							},
+						],
+						"priority": 50,
+						"type":     "REGULAR",
+					},
+				],
+				"metric_name": "example",
+				"name":        "example",
+				"tags":        null,
+			},
+		},
+	},
+}
+
+variables = {}
+
+resource_changes = {
+	"aws_waf_rule.example": {
+		"address": "aws_waf_rule.example",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"metric_name": "example",
+				"name":        "example",
+				"predicates":  [],
+				"tags":        null,
+			},
+			"after_unknown": {
+				"arn":        true,
+				"id":         true,
+				"predicates": [],
+				"tags_all":   true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "example",
+		"provider_name":  "registry.terraform.io/hashicorp/aws",
+		"type":           "aws_waf_rule",
+	},
+	"aws_waf_rule_group.example": {
+		"address": "aws_waf_rule_group.example",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"activated_rule": [
+					{
+						"action": [
+							{
+								"type": "COUNT",
+							},
+						],
+						"priority": 50,
+						"type":     "REGULAR",
+					},
+				],
+				"metric_name": "example",
+				"name":        "example",
+				"tags":        null,
+			},
+			"after_unknown": {
+				"activated_rule": [
+					{
+						"action": [
+							{},
+						],
+						"rule_id": true,
+					},
+				],
+				"arn":      true,
+				"id":       true,
+				"tags_all": true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "example",
+		"provider_name":  "registry.terraform.io/hashicorp/aws",
+		"type":           "aws_waf_rule_group",
+	},
+}
+
+resource_drift = {}
+
+output_changes = {}
+
+raw = {
+	"complete": true,
+	"configuration": {
+		"provider_config": {
+			"aws": {
+				"expressions": {
+					"region": {
+						"constant_value": "us-east-1",
+					},
+				},
+				"full_name": "registry.terraform.io/hashicorp/aws",
+				"name":      "aws",
+			},
+		},
+		"root_module": {
+			"resources": [
+				{
+					"address": "aws_waf_rule.example",
+					"expressions": {
+						"metric_name": {
+							"constant_value": "example",
+						},
+						"name": {
+							"constant_value": "example",
+						},
+					},
+					"mode":                "managed",
+					"name":                "example",
+					"provider_config_key": "aws",
+					"schema_version":      0,
+					"type":                "aws_waf_rule",
+				},
+				{
+					"address": "aws_waf_rule_group.example",
+					"expressions": {
+						"activated_rule": [
+							{
+								"action": [
+									{
+										"type": {
+											"constant_value": "COUNT",
+										},
+									},
+								],
+								"priority": {
+									"constant_value": 50,
+								},
+								"rule_id": {
+									"references": [
+										"aws_waf_rule.example.id",
+										"aws_waf_rule.example",
+									],
+								},
+							},
+						],
+						"metric_name": {
+							"constant_value": "example",
+						},
+						"name": {
+							"constant_value": "example",
+						},
+					},
+					"mode":                "managed",
+					"name":                "example",
+					"provider_config_key": "aws",
+					"schema_version":      0,
+					"type":                "aws_waf_rule_group",
+				},
+			],
+		},
+	},
+	"format_version": "1.2",
+	"planned_values": {
+		"root_module": {
+			"resources": [
+				{
+					"address":        "aws_waf_rule.example",
+					"mode":           "managed",
+					"name":           "example",
+					"provider_name":  "registry.terraform.io/hashicorp/aws",
+					"schema_version": 0,
+					"sensitive_values": {
+						"predicates": [],
+						"tags_all":   {},
+					},
+					"type": "aws_waf_rule",
+					"values": {
+						"metric_name": "example",
+						"name":        "example",
+						"predicates":  [],
+						"tags":        null,
+					},
+				},
+				{
+					"address":        "aws_waf_rule_group.example",
+					"mode":           "managed",
+					"name":           "example",
+					"provider_name":  "registry.terraform.io/hashicorp/aws",
+					"schema_version": 0,
+					"sensitive_values": {
+						"activated_rule": [
+							{
+								"action": [
+									{},
+								],
+							},
+						],
+						"tags_all": {},
+					},
+					"type": "aws_waf_rule_group",
+					"values": {
+						"activated_rule": [
+							{
+								"action": [
+									{
+										"type": "COUNT",
+									},
+								],
+								"priority": 50,
+								"type":     "REGULAR",
+							},
+						],
+						"metric_name": "example",
+						"name":        "example",
+						"tags":        null,
+					},
+				},
+			],
+		},
+	},
+	"relevant_attributes": [
+		{
+			"attribute": [
+				"id",
+			],
+			"resource": "aws_waf_rule.example",
+		},
+	],
+	"resource_changes": [
+		{
+			"address": "aws_waf_rule.example",
+			"change": {
+				"actions": [
+					"create",
+				],
+				"after": {
+					"metric_name": "example",
+					"name":        "example",
+					"predicates":  [],
+					"tags":        null,
+				},
+				"after_sensitive": {
+					"predicates": [],
+					"tags_all":   {},
+				},
+				"after_unknown": {
+					"arn":        true,
+					"id":         true,
+					"predicates": [],
+					"tags_all":   true,
+				},
+				"before":           null,
+				"before_sensitive": false,
+			},
+			"mode":          "managed",
+			"name":          "example",
+			"provider_name": "registry.terraform.io/hashicorp/aws",
+			"type":          "aws_waf_rule",
+		},
+		{
+			"address": "aws_waf_rule_group.example",
+			"change": {
+				"actions": [
+					"create",
+				],
+				"after": {
+					"activated_rule": [
+						{
+							"action": [
+								{
+									"type": "COUNT",
+								},
+							],
+							"priority": 50,
+							"type":     "REGULAR",
+						},
+					],
+					"metric_name": "example",
+					"name":        "example",
+					"tags":        null,
+				},
+				"after_sensitive": {
+					"activated_rule": [
+						{
+							"action": [
+								{},
+							],
+						},
+					],
+					"tags_all": {},
+				},
+				"after_unknown": {
+					"activated_rule": [
+						{
+							"action": [
+								{},
+							],
+							"rule_id": true,
+						},
+					],
+					"arn":      true,
+					"id":       true,
+					"tags_all": true,
+				},
+				"before":           null,
+				"before_sensitive": false,
+			},
+			"mode":          "managed",
+			"name":          "example",
+			"provider_name": "registry.terraform.io/hashicorp/aws",
+			"type":          "aws_waf_rule_group",
+		},
+	],
+	"terraform_version": "1.10.2",
+	"timestamp":         "2025-04-07T20:01:19Z",
+}

--- a/policies/test/waf-global-rulegroup-not-empty/success-rules-are-not-empty.hcl
+++ b/policies/test/waf-global-rulegroup-not-empty/success-rules-are-not-empty.hcl
@@ -1,0 +1,23 @@
+mock "tfplan/v2" {
+	module {
+		source = "./mocks/policy-success-rules-are-not-empty/mock-tfplan-v2.sentinel"
+	}
+}
+
+
+
+import "plugin" "tfresources" {
+	source = "../../../plugins/darwin/arm64/sentinel-plugin-tfresources"
+}
+
+mock "report" {
+	module {
+		source = "../../../modules/mocks/report/report.sentinel"
+	}
+}
+
+test {
+	rules = {
+		main = true
+	}
+}

--- a/policies/waf-global-rulegroup-not-empty.sentinel
+++ b/policies/waf-global-rulegroup-not-empty.sentinel
@@ -1,0 +1,46 @@
+# This policy requires resources of type `aws_waf_rule_group` to have at least one rule.
+
+# Imports
+
+import "tfplan/v2" as tfplan
+import "tfresources" as tf
+import "report" as report
+import "collection" as collection
+import "collection/maps" as maps
+
+# Constants
+
+const = {
+	"policy_name":                 "waf-global-rulegroup-not-empty",
+	"message":                     "AWS WAF Classic global rule groups should have at least one rule. Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/waf-controls.html#waf-7 for more details.",
+	"resource_aws_waf_rule_group": "aws_waf_rule_group",
+	"activated_rule":              "activated_rule",
+}
+
+# Variables
+
+resources = tf.plan(tfplan.planned_values.resources).type(const.resource_aws_waf_rule_group).resources
+violations = collection.reject(resources, func(res) {
+	return maps.get(res.values, const.activated_rule, []) is not empty
+})
+
+summary = {
+	"policy_name": const.policy_name,
+	"violations": map violations as _, v {
+		{
+			"address":        v.address,
+			"module_address": v.module_address,
+			"message":        const.message,
+		}
+	},
+}
+
+# Outputs
+
+print(report.generate_policy_report(summary))
+
+# Rules
+
+main = rule {
+	violations is empty
+}

--- a/sentinel.hcl
+++ b/sentinel.hcl
@@ -973,3 +973,8 @@ policy "kinesis-firehose-delivery-stream-encrypted" {
   source = "./policies/kinesis-firehose-delivery-stream-encrypted.sentinel"
   enforcement_level = "advisory"
 }
+
+policy "waf-global-rulegroup-not-empty" {
+  source = "./policies/waf-global-rulegroup-not-empty.sentinel"
+  enforcement_level = "advisory"
+}

--- a/tests/acceptance/waf-global-rulegroup-not-empty/cases/rules-are-empty/backend.tf
+++ b/tests/acceptance/waf-global-rulegroup-not-empty/cases/rules-are-empty/backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  cloud {
+    workspaces {
+      name = "waf-global-rulegroup-not-empty"
+    }
+  }
+}

--- a/tests/acceptance/waf-global-rulegroup-not-empty/cases/rules-are-empty/main.tf
+++ b/tests/acceptance/waf-global-rulegroup-not-empty/cases/rules-are-empty/main.tf
@@ -1,0 +1,8 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+resource "aws_waf_rule_group" "example" {
+  name        = "example"
+  metric_name = "example"
+}

--- a/tests/acceptance/waf-global-rulegroup-not-empty/cases/rules-are-not-empty/backend.tf
+++ b/tests/acceptance/waf-global-rulegroup-not-empty/cases/rules-are-not-empty/backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  cloud {
+    workspaces {
+      name = "waf-global-rulegroup-not-empty"
+    }
+  }
+}

--- a/tests/acceptance/waf-global-rulegroup-not-empty/cases/rules-are-not-empty/main.tf
+++ b/tests/acceptance/waf-global-rulegroup-not-empty/cases/rules-are-not-empty/main.tf
@@ -1,0 +1,22 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+resource "aws_waf_rule" "example" {
+  name        = "example"
+  metric_name = "example"
+}
+
+resource "aws_waf_rule_group" "example" {
+  name        = "example"
+  metric_name = "example"
+
+  activated_rule {
+    action {
+      type = "COUNT"
+    }
+
+    priority = 50
+    rule_id  = aws_waf_rule.example.id
+  }
+}

--- a/tests/acceptance/waf-global-rulegroup-not-empty/test-config.hcl
+++ b/tests/acceptance/waf-global-rulegroup-not-empty/test-config.hcl
@@ -1,0 +1,17 @@
+name = "waf-global-rulegroup-not-empty"
+
+disabled = false
+
+case "Waf Global Rulegroup Not Empty" {
+    path = "./cases/rules-are-not-empty"
+    expectation {
+        result = true
+    }
+}
+
+case "Waf Global Rulegroup Empty" {
+    path = "./cases/rules-are-empty"
+    expectation {
+        result = false
+    }
+}


### PR DESCRIPTION
## Changes proposed in this PR:
- Added waf-global-rulegroup-not-empty

## Documentation
- [AWS Standard](https://docs.aws.amazon.com/securityhub/latest/userguide/waf-controls.html#waf-7)
- [Policy details](https://docs.aws.amazon.com/securityhub/latest/userguide/waf-controls.html#waf-7)

## AWS Provider version
<!-- Add information about the provider version against which the policy was tested/developed with. This will later help us when we deal with documentation.Add any nuances that you've observed around provider versions. For example, some attributes will only be present in a certain version of a provider and we need to clearly document that so that users use the expected version.-->

## How I've tested this PR:

## Checklist:
- [x] Tests added