### PR TITLE
Added wafv2-webacl-not-empty

### DIFF
--- a/docs/policies/wafv2-webacl-not-empty.md
+++ b/docs/policies/wafv2-webacl-not-empty.md
@@ -1,0 +1,67 @@
+# AWS WAF web ACLs should have at least one rule or rule group
+
+| Provider            | Category                     |
+|---------------------|------------------------------|
+| Amazon Web Services | Secure network configuration |
+
+## Description
+
+This control checks whether an AWS WAFV2 web access control list (web ACL) contains at least one rule or rule group. The control fails if a web ACL does not contain any rules or rule groups.
+
+A web ACL gives you fine-grained control over all of the HTTP(S) web requests that your protected resource responds to. A web ACL should contain a collection of rules and rule groups that inspect and control web requests. If a web ACL is empty, the web traffic can pass without being detected or acted upon by AWS WAF depending on the default action.
+
+This rule is covered by the [wafv2-webacl-not-empty](../../policies/wafv2-webacl-not-empty.sentinel) policy.
+
+## Policy Results (Pass)
+```bash
+trace:
+      Pass - wafv2-webacl-not-empty.sentinel
+
+      Description:
+        This policy requires resources of type `aws_wafv2_web_acl` to have at least
+        one rule or rule group.
+
+      Print messages:
+
+      → → Overall Result: true
+
+      This result means that all resources have passed the policy check for the policy wafv2-webacl-not-empty.
+
+      ✓ Found 0 resource violations
+
+      wafv2-webacl-not-empty.sentinel:51:1 - Rule "main"
+        Value:
+          true
+```
+
+---
+
+## Policy Results (Fail)
+```bash
+trace:
+      Fail - wafv2-webacl-not-empty.sentinel
+
+      Description:
+        This policy requires resources of type `aws_wafv2_web_acl` to have at least
+        one rule or rule group.
+
+      Print messages:
+
+      → → Overall Result: false
+
+      This result means that not all resources passed the policy check and the protected behavior is not allowed for the policy wafv2-webacl-not-empty.
+
+      Found 1 resource violations
+
+      → Module name: root
+        ↳ Resource Address: aws_wafv2_web_acl.example
+          | ✗ failed
+          | AWS WAF web ACLs should have at least one rule or rule group. Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/waf-controls.html#waf-10 for more details.
+
+
+      wafv2-webacl-not-empty.sentinel:51:1 - Rule "main"
+        Value:
+          false
+```
+
+---

--- a/policies/test/wafv2-webacl-not-empty/failure-rules-are-not-present.hcl
+++ b/policies/test/wafv2-webacl-not-empty/failure-rules-are-not-present.hcl
@@ -1,0 +1,23 @@
+mock "tfplan/v2" {
+	module {
+		source = "./mocks/policy-failure-rules-are-not-present/mock-tfplan-v2.sentinel"
+	}
+}
+
+
+
+import "plugin" "tfresources" {
+	source = "../../../plugins/darwin/arm64/sentinel-plugin-tfresources"
+}
+
+mock "report" {
+	module {
+		source = "../../../modules/mocks/report/report.sentinel"
+	}
+}
+
+test {
+	rules = {
+		main = false
+	}
+}

--- a/policies/test/wafv2-webacl-not-empty/mocks/policy-failure-rules-are-not-present/mock-tfplan-v2.sentinel
+++ b/policies/test/wafv2-webacl-not-empty/mocks/policy-failure-rules-are-not-present/mock-tfplan-v2.sentinel
@@ -1,0 +1,425 @@
+terraform_version = "1.10.2"
+
+planned_values = {
+	"outputs": {},
+	"resources": {
+		"aws_wafv2_web_acl.example": {
+			"address":        "aws_wafv2_web_acl.example",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "example",
+			"provider_name":  "registry.terraform.io/hashicorp/aws",
+			"tainted":        false,
+			"type":           "aws_wafv2_web_acl",
+			"values": {
+				"association_config":   [],
+				"captcha_config":       [],
+				"challenge_config":     [],
+				"custom_response_body": [],
+				"default_action": [
+					{
+						"allow": [
+							{
+								"custom_request_handling": [],
+							},
+						],
+						"block": [],
+					},
+				],
+				"description": "Example of a managed rule.",
+				"name":        "managed-rule-example",
+				"rule":        [],
+				"rule_json":   null,
+				"scope":       "REGIONAL",
+				"tags": {
+					"Tag1": "Value1",
+					"Tag2": "Value2",
+				},
+				"tags_all": {
+					"Tag1": "Value1",
+					"Tag2": "Value2",
+				},
+				"token_domains": [
+					"myotherwebsite.com",
+					"mywebsite.com",
+				],
+				"visibility_config": [
+					{
+						"cloudwatch_metrics_enabled": false,
+						"metric_name":                "friendly-metric-name",
+						"sampled_requests_enabled":   false,
+					},
+				],
+			},
+		},
+	},
+}
+
+variables = {}
+
+resource_changes = {
+	"aws_wafv2_web_acl.example": {
+		"address": "aws_wafv2_web_acl.example",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"association_config":   [],
+				"captcha_config":       [],
+				"challenge_config":     [],
+				"custom_response_body": [],
+				"default_action": [
+					{
+						"allow": [
+							{
+								"custom_request_handling": [],
+							},
+						],
+						"block": [],
+					},
+				],
+				"description": "Example of a managed rule.",
+				"name":        "managed-rule-example",
+				"rule":        [],
+				"rule_json":   null,
+				"scope":       "REGIONAL",
+				"tags": {
+					"Tag1": "Value1",
+					"Tag2": "Value2",
+				},
+				"tags_all": {
+					"Tag1": "Value1",
+					"Tag2": "Value2",
+				},
+				"token_domains": [
+					"myotherwebsite.com",
+					"mywebsite.com",
+				],
+				"visibility_config": [
+					{
+						"cloudwatch_metrics_enabled": false,
+						"metric_name":                "friendly-metric-name",
+						"sampled_requests_enabled":   false,
+					},
+				],
+			},
+			"after_unknown": {
+				"application_integration_url": true,
+				"arn":                  true,
+				"association_config":   [],
+				"capacity":             true,
+				"captcha_config":       [],
+				"challenge_config":     [],
+				"custom_response_body": [],
+				"default_action": [
+					{
+						"allow": [
+							{
+								"custom_request_handling": [],
+							},
+						],
+						"block": [],
+					},
+				],
+				"id":          true,
+				"lock_token":  true,
+				"name_prefix": true,
+				"rule":        [],
+				"tags":        {},
+				"tags_all":    {},
+				"token_domains": [
+					false,
+					false,
+				],
+				"visibility_config": [
+					{},
+				],
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "example",
+		"provider_name":  "registry.terraform.io/hashicorp/aws",
+		"type":           "aws_wafv2_web_acl",
+	},
+}
+
+resource_drift = {}
+
+output_changes = {}
+
+raw = {
+	"complete": true,
+	"configuration": {
+		"provider_config": {
+			"aws": {
+				"expressions": {
+					"region": {
+						"constant_value": "us-east-1",
+					},
+				},
+				"full_name": "registry.terraform.io/hashicorp/aws",
+				"name":      "aws",
+			},
+		},
+		"root_module": {
+			"resources": [
+				{
+					"address": "aws_wafv2_web_acl.example",
+					"expressions": {
+						"default_action": [
+							{
+								"allow": [
+									{},
+								],
+							},
+						],
+						"description": {
+							"constant_value": "Example of a managed rule.",
+						},
+						"name": {
+							"constant_value": "managed-rule-example",
+						},
+						"scope": {
+							"constant_value": "REGIONAL",
+						},
+						"tags": {
+							"constant_value": {
+								"Tag1": "Value1",
+								"Tag2": "Value2",
+							},
+						},
+						"token_domains": {
+							"constant_value": [
+								"mywebsite.com",
+								"myotherwebsite.com",
+							],
+						},
+						"visibility_config": [
+							{
+								"cloudwatch_metrics_enabled": {
+									"constant_value": false,
+								},
+								"metric_name": {
+									"constant_value": "friendly-metric-name",
+								},
+								"sampled_requests_enabled": {
+									"constant_value": false,
+								},
+							},
+						],
+					},
+					"mode":                "managed",
+					"name":                "example",
+					"provider_config_key": "aws",
+					"schema_version":      0,
+					"type":                "aws_wafv2_web_acl",
+				},
+			],
+		},
+	},
+	"format_version": "1.2",
+	"planned_values": {
+		"root_module": {
+			"resources": [
+				{
+					"address":        "aws_wafv2_web_acl.example",
+					"mode":           "managed",
+					"name":           "example",
+					"provider_name":  "registry.terraform.io/hashicorp/aws",
+					"schema_version": 0,
+					"sensitive_values": {
+						"association_config":   [],
+						"captcha_config":       [],
+						"challenge_config":     [],
+						"custom_response_body": [],
+						"default_action": [
+							{
+								"allow": [
+									{
+										"custom_request_handling": [],
+									},
+								],
+								"block": [],
+							},
+						],
+						"rule":     [],
+						"tags":     {},
+						"tags_all": {},
+						"token_domains": [
+							false,
+							false,
+						],
+						"visibility_config": [
+							{},
+						],
+					},
+					"type": "aws_wafv2_web_acl",
+					"values": {
+						"association_config":   [],
+						"captcha_config":       [],
+						"challenge_config":     [],
+						"custom_response_body": [],
+						"default_action": [
+							{
+								"allow": [
+									{
+										"custom_request_handling": [],
+									},
+								],
+								"block": [],
+							},
+						],
+						"description": "Example of a managed rule.",
+						"name":        "managed-rule-example",
+						"rule":        [],
+						"rule_json":   null,
+						"scope":       "REGIONAL",
+						"tags": {
+							"Tag1": "Value1",
+							"Tag2": "Value2",
+						},
+						"tags_all": {
+							"Tag1": "Value1",
+							"Tag2": "Value2",
+						},
+						"token_domains": [
+							"myotherwebsite.com",
+							"mywebsite.com",
+						],
+						"visibility_config": [
+							{
+								"cloudwatch_metrics_enabled": false,
+								"metric_name":                "friendly-metric-name",
+								"sampled_requests_enabled":   false,
+							},
+						],
+					},
+				},
+			],
+		},
+	},
+	"resource_changes": [
+		{
+			"address": "aws_wafv2_web_acl.example",
+			"change": {
+				"actions": [
+					"create",
+				],
+				"after": {
+					"association_config":   [],
+					"captcha_config":       [],
+					"challenge_config":     [],
+					"custom_response_body": [],
+					"default_action": [
+						{
+							"allow": [
+								{
+									"custom_request_handling": [],
+								},
+							],
+							"block": [],
+						},
+					],
+					"description": "Example of a managed rule.",
+					"name":        "managed-rule-example",
+					"rule":        [],
+					"rule_json":   null,
+					"scope":       "REGIONAL",
+					"tags": {
+						"Tag1": "Value1",
+						"Tag2": "Value2",
+					},
+					"tags_all": {
+						"Tag1": "Value1",
+						"Tag2": "Value2",
+					},
+					"token_domains": [
+						"myotherwebsite.com",
+						"mywebsite.com",
+					],
+					"visibility_config": [
+						{
+							"cloudwatch_metrics_enabled": false,
+							"metric_name":                "friendly-metric-name",
+							"sampled_requests_enabled":   false,
+						},
+					],
+				},
+				"after_sensitive": {
+					"association_config":   [],
+					"captcha_config":       [],
+					"challenge_config":     [],
+					"custom_response_body": [],
+					"default_action": [
+						{
+							"allow": [
+								{
+									"custom_request_handling": [],
+								},
+							],
+							"block": [],
+						},
+					],
+					"rule":     [],
+					"tags":     {},
+					"tags_all": {},
+					"token_domains": [
+						false,
+						false,
+					],
+					"visibility_config": [
+						{},
+					],
+				},
+				"after_unknown": {
+					"application_integration_url": true,
+					"arn":                  true,
+					"association_config":   [],
+					"capacity":             true,
+					"captcha_config":       [],
+					"challenge_config":     [],
+					"custom_response_body": [],
+					"default_action": [
+						{
+							"allow": [
+								{
+									"custom_request_handling": [],
+								},
+							],
+							"block": [],
+						},
+					],
+					"id":          true,
+					"lock_token":  true,
+					"name_prefix": true,
+					"rule":        [],
+					"tags":        {},
+					"tags_all":    {},
+					"token_domains": [
+						false,
+						false,
+					],
+					"visibility_config": [
+						{},
+					],
+				},
+				"before":           null,
+				"before_sensitive": false,
+			},
+			"mode":          "managed",
+			"name":          "example",
+			"provider_name": "registry.terraform.io/hashicorp/aws",
+			"type":          "aws_wafv2_web_acl",
+		},
+	],
+	"terraform_version": "1.10.2",
+	"timestamp":         "2025-04-08T05:37:43Z",
+}

--- a/policies/test/wafv2-webacl-not-empty/mocks/policy-success-multiple-rules-are-present/mock-tfplan-v2.sentinel
+++ b/policies/test/wafv2-webacl-not-empty/mocks/policy-success-multiple-rules-are-present/mock-tfplan-v2.sentinel
@@ -1,0 +1,2227 @@
+terraform_version = "1.10.2"
+
+planned_values = {
+	"outputs": {},
+	"resources": {
+		"aws_wafv2_web_acl.example": {
+			"address":        "aws_wafv2_web_acl.example",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "example",
+			"provider_name":  "registry.terraform.io/hashicorp/aws",
+			"tainted":        false,
+			"type":           "aws_wafv2_web_acl",
+			"values": {
+				"association_config":   [],
+				"captcha_config":       [],
+				"challenge_config":     [],
+				"custom_response_body": [],
+				"default_action": [
+					{
+						"allow": [
+							{
+								"custom_request_handling": [],
+							},
+						],
+						"block": [],
+					},
+				],
+				"description": "Example of a managed rule.",
+				"name":        "managed-rule-example",
+				"rule": [
+					{
+						"action": [
+							{
+								"allow": [
+									{
+										"custom_request_handling": [],
+									},
+								],
+								"block":     [],
+								"captcha":   [],
+								"challenge": [],
+								"count":     [],
+							},
+						],
+						"captcha_config":   [],
+						"challenge_config": [],
+						"name":             "rule-to-exclude-a",
+						"override_action":  [],
+						"priority":         10,
+						"rule_label":       [],
+						"statement": [
+							{
+								"and_statement":        [],
+								"byte_match_statement": [],
+								"geo_match_statement": [
+									{
+										"country_codes": [
+											"US",
+										],
+										"forwarded_ip_config": [],
+									},
+								],
+								"ip_set_reference_statement":            [],
+								"label_match_statement":                 [],
+								"managed_rule_group_statement":          [],
+								"not_statement":                         [],
+								"or_statement":                          [],
+								"rate_based_statement":                  [],
+								"regex_match_statement":                 [],
+								"regex_pattern_set_reference_statement": [],
+								"rule_group_reference_statement":        [],
+								"size_constraint_statement":             [],
+								"sqli_match_statement":                  [],
+								"xss_match_statement":                   [],
+							},
+						],
+						"visibility_config": [
+							{
+								"cloudwatch_metrics_enabled": false,
+								"metric_name":                "friendly-rule-metric-name",
+								"sampled_requests_enabled":   false,
+							},
+						],
+					},
+					{
+						"action": [
+							{
+								"allow": [
+									{
+										"custom_request_handling": [],
+									},
+								],
+								"block":     [],
+								"captcha":   [],
+								"challenge": [],
+								"count":     [],
+							},
+						],
+						"captcha_config":   [],
+						"challenge_config": [],
+						"name":             "rule-to-exclude-b",
+						"override_action":  [],
+						"priority":         15,
+						"rule_label":       [],
+						"statement": [
+							{
+								"and_statement":        [],
+								"byte_match_statement": [],
+								"geo_match_statement": [
+									{
+										"country_codes": [
+											"GB",
+										],
+										"forwarded_ip_config": [],
+									},
+								],
+								"ip_set_reference_statement":            [],
+								"label_match_statement":                 [],
+								"managed_rule_group_statement":          [],
+								"not_statement":                         [],
+								"or_statement":                          [],
+								"rate_based_statement":                  [],
+								"regex_match_statement":                 [],
+								"regex_pattern_set_reference_statement": [],
+								"rule_group_reference_statement":        [],
+								"size_constraint_statement":             [],
+								"sqli_match_statement":                  [],
+								"xss_match_statement":                   [],
+							},
+						],
+						"visibility_config": [
+							{
+								"cloudwatch_metrics_enabled": false,
+								"metric_name":                "friendly-rule-metric-name",
+								"sampled_requests_enabled":   false,
+							},
+						],
+					},
+					{
+						"action":           [],
+						"captcha_config":   [],
+						"challenge_config": [],
+						"name":             "rule-1",
+						"override_action": [
+							{
+								"count": [
+									{},
+								],
+								"none": [],
+							},
+						],
+						"priority":   1,
+						"rule_label": [],
+						"statement": [
+							{
+								"and_statement":              [],
+								"byte_match_statement":       [],
+								"geo_match_statement":        [],
+								"ip_set_reference_statement": [],
+								"label_match_statement":      [],
+								"managed_rule_group_statement": [
+									{
+										"managed_rule_group_configs": [],
+										"name": "AWSManagedRulesCommonRuleSet",
+										"rule_action_override": [
+											{
+												"action_to_use": [
+													{
+														"allow":     [],
+														"block":     [],
+														"captcha":   [],
+														"challenge": [],
+														"count": [
+															{
+																"custom_request_handling": [],
+															},
+														],
+													},
+												],
+												"name": "SizeRestrictions_QUERYSTRING",
+											},
+											{
+												"action_to_use": [
+													{
+														"allow":     [],
+														"block":     [],
+														"captcha":   [],
+														"challenge": [],
+														"count": [
+															{
+																"custom_request_handling": [],
+															},
+														],
+													},
+												],
+												"name": "NoUserAgent_HEADER",
+											},
+										],
+										"scope_down_statement": [
+											{
+												"and_statement":        [],
+												"byte_match_statement": [],
+												"geo_match_statement": [
+													{
+														"country_codes": [
+															"US",
+															"NL",
+														],
+														"forwarded_ip_config": [],
+													},
+												],
+												"ip_set_reference_statement":            [],
+												"label_match_statement":                 [],
+												"not_statement":                         [],
+												"or_statement":                          [],
+												"regex_match_statement":                 [],
+												"regex_pattern_set_reference_statement": [],
+												"size_constraint_statement":             [],
+												"sqli_match_statement":                  [],
+												"xss_match_statement":                   [],
+											},
+										],
+										"vendor_name": "AWS",
+										"version":     "",
+									},
+								],
+								"not_statement":                         [],
+								"or_statement":                          [],
+								"rate_based_statement":                  [],
+								"regex_match_statement":                 [],
+								"regex_pattern_set_reference_statement": [],
+								"rule_group_reference_statement":        [],
+								"size_constraint_statement":             [],
+								"sqli_match_statement":                  [],
+								"xss_match_statement":                   [],
+							},
+						],
+						"visibility_config": [
+							{
+								"cloudwatch_metrics_enabled": false,
+								"metric_name":                "friendly-rule-metric-name",
+								"sampled_requests_enabled":   false,
+							},
+						],
+					},
+				],
+				"rule_json": null,
+				"scope":     "REGIONAL",
+				"tags": {
+					"Tag1": "Value1",
+					"Tag2": "Value2",
+				},
+				"tags_all": {
+					"Tag1": "Value1",
+					"Tag2": "Value2",
+				},
+				"token_domains": [
+					"myotherwebsite.com",
+					"mywebsite.com",
+				],
+				"visibility_config": [
+					{
+						"cloudwatch_metrics_enabled": false,
+						"metric_name":                "friendly-metric-name",
+						"sampled_requests_enabled":   false,
+					},
+				],
+			},
+		},
+	},
+}
+
+variables = {}
+
+resource_changes = {
+	"aws_wafv2_web_acl.example": {
+		"address": "aws_wafv2_web_acl.example",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"association_config":   [],
+				"captcha_config":       [],
+				"challenge_config":     [],
+				"custom_response_body": [],
+				"default_action": [
+					{
+						"allow": [
+							{
+								"custom_request_handling": [],
+							},
+						],
+						"block": [],
+					},
+				],
+				"description": "Example of a managed rule.",
+				"name":        "managed-rule-example",
+				"rule": [
+					{
+						"action": [
+							{
+								"allow": [
+									{
+										"custom_request_handling": [],
+									},
+								],
+								"block":     [],
+								"captcha":   [],
+								"challenge": [],
+								"count":     [],
+							},
+						],
+						"captcha_config":   [],
+						"challenge_config": [],
+						"name":             "rule-to-exclude-a",
+						"override_action":  [],
+						"priority":         10,
+						"rule_label":       [],
+						"statement": [
+							{
+								"and_statement":        [],
+								"byte_match_statement": [],
+								"geo_match_statement": [
+									{
+										"country_codes": [
+											"US",
+										],
+										"forwarded_ip_config": [],
+									},
+								],
+								"ip_set_reference_statement":            [],
+								"label_match_statement":                 [],
+								"managed_rule_group_statement":          [],
+								"not_statement":                         [],
+								"or_statement":                          [],
+								"rate_based_statement":                  [],
+								"regex_match_statement":                 [],
+								"regex_pattern_set_reference_statement": [],
+								"rule_group_reference_statement":        [],
+								"size_constraint_statement":             [],
+								"sqli_match_statement":                  [],
+								"xss_match_statement":                   [],
+							},
+						],
+						"visibility_config": [
+							{
+								"cloudwatch_metrics_enabled": false,
+								"metric_name":                "friendly-rule-metric-name",
+								"sampled_requests_enabled":   false,
+							},
+						],
+					},
+					{
+						"action": [
+							{
+								"allow": [
+									{
+										"custom_request_handling": [],
+									},
+								],
+								"block":     [],
+								"captcha":   [],
+								"challenge": [],
+								"count":     [],
+							},
+						],
+						"captcha_config":   [],
+						"challenge_config": [],
+						"name":             "rule-to-exclude-b",
+						"override_action":  [],
+						"priority":         15,
+						"rule_label":       [],
+						"statement": [
+							{
+								"and_statement":        [],
+								"byte_match_statement": [],
+								"geo_match_statement": [
+									{
+										"country_codes": [
+											"GB",
+										],
+										"forwarded_ip_config": [],
+									},
+								],
+								"ip_set_reference_statement":            [],
+								"label_match_statement":                 [],
+								"managed_rule_group_statement":          [],
+								"not_statement":                         [],
+								"or_statement":                          [],
+								"rate_based_statement":                  [],
+								"regex_match_statement":                 [],
+								"regex_pattern_set_reference_statement": [],
+								"rule_group_reference_statement":        [],
+								"size_constraint_statement":             [],
+								"sqli_match_statement":                  [],
+								"xss_match_statement":                   [],
+							},
+						],
+						"visibility_config": [
+							{
+								"cloudwatch_metrics_enabled": false,
+								"metric_name":                "friendly-rule-metric-name",
+								"sampled_requests_enabled":   false,
+							},
+						],
+					},
+					{
+						"action":           [],
+						"captcha_config":   [],
+						"challenge_config": [],
+						"name":             "rule-1",
+						"override_action": [
+							{
+								"count": [
+									{},
+								],
+								"none": [],
+							},
+						],
+						"priority":   1,
+						"rule_label": [],
+						"statement": [
+							{
+								"and_statement":              [],
+								"byte_match_statement":       [],
+								"geo_match_statement":        [],
+								"ip_set_reference_statement": [],
+								"label_match_statement":      [],
+								"managed_rule_group_statement": [
+									{
+										"managed_rule_group_configs": [],
+										"name": "AWSManagedRulesCommonRuleSet",
+										"rule_action_override": [
+											{
+												"action_to_use": [
+													{
+														"allow":     [],
+														"block":     [],
+														"captcha":   [],
+														"challenge": [],
+														"count": [
+															{
+																"custom_request_handling": [],
+															},
+														],
+													},
+												],
+												"name": "SizeRestrictions_QUERYSTRING",
+											},
+											{
+												"action_to_use": [
+													{
+														"allow":     [],
+														"block":     [],
+														"captcha":   [],
+														"challenge": [],
+														"count": [
+															{
+																"custom_request_handling": [],
+															},
+														],
+													},
+												],
+												"name": "NoUserAgent_HEADER",
+											},
+										],
+										"scope_down_statement": [
+											{
+												"and_statement":        [],
+												"byte_match_statement": [],
+												"geo_match_statement": [
+													{
+														"country_codes": [
+															"US",
+															"NL",
+														],
+														"forwarded_ip_config": [],
+													},
+												],
+												"ip_set_reference_statement":            [],
+												"label_match_statement":                 [],
+												"not_statement":                         [],
+												"or_statement":                          [],
+												"regex_match_statement":                 [],
+												"regex_pattern_set_reference_statement": [],
+												"size_constraint_statement":             [],
+												"sqli_match_statement":                  [],
+												"xss_match_statement":                   [],
+											},
+										],
+										"vendor_name": "AWS",
+										"version":     "",
+									},
+								],
+								"not_statement":                         [],
+								"or_statement":                          [],
+								"rate_based_statement":                  [],
+								"regex_match_statement":                 [],
+								"regex_pattern_set_reference_statement": [],
+								"rule_group_reference_statement":        [],
+								"size_constraint_statement":             [],
+								"sqli_match_statement":                  [],
+								"xss_match_statement":                   [],
+							},
+						],
+						"visibility_config": [
+							{
+								"cloudwatch_metrics_enabled": false,
+								"metric_name":                "friendly-rule-metric-name",
+								"sampled_requests_enabled":   false,
+							},
+						],
+					},
+				],
+				"rule_json": null,
+				"scope":     "REGIONAL",
+				"tags": {
+					"Tag1": "Value1",
+					"Tag2": "Value2",
+				},
+				"tags_all": {
+					"Tag1": "Value1",
+					"Tag2": "Value2",
+				},
+				"token_domains": [
+					"myotherwebsite.com",
+					"mywebsite.com",
+				],
+				"visibility_config": [
+					{
+						"cloudwatch_metrics_enabled": false,
+						"metric_name":                "friendly-metric-name",
+						"sampled_requests_enabled":   false,
+					},
+				],
+			},
+			"after_unknown": {
+				"application_integration_url": true,
+				"arn":                  true,
+				"association_config":   [],
+				"capacity":             true,
+				"captcha_config":       [],
+				"challenge_config":     [],
+				"custom_response_body": [],
+				"default_action": [
+					{
+						"allow": [
+							{
+								"custom_request_handling": [],
+							},
+						],
+						"block": [],
+					},
+				],
+				"id":          true,
+				"lock_token":  true,
+				"name_prefix": true,
+				"rule": [
+					{
+						"action": [
+							{
+								"allow": [
+									{
+										"custom_request_handling": [],
+									},
+								],
+								"block":     [],
+								"captcha":   [],
+								"challenge": [],
+								"count":     [],
+							},
+						],
+						"captcha_config":   [],
+						"challenge_config": [],
+						"override_action":  [],
+						"rule_label":       [],
+						"statement": [
+							{
+								"and_statement":        [],
+								"byte_match_statement": [],
+								"geo_match_statement": [
+									{
+										"country_codes": [
+											false,
+										],
+										"forwarded_ip_config": [],
+									},
+								],
+								"ip_set_reference_statement":            [],
+								"label_match_statement":                 [],
+								"managed_rule_group_statement":          [],
+								"not_statement":                         [],
+								"or_statement":                          [],
+								"rate_based_statement":                  [],
+								"regex_match_statement":                 [],
+								"regex_pattern_set_reference_statement": [],
+								"rule_group_reference_statement":        [],
+								"size_constraint_statement":             [],
+								"sqli_match_statement":                  [],
+								"xss_match_statement":                   [],
+							},
+						],
+						"visibility_config": [
+							{},
+						],
+					},
+					{
+						"action": [
+							{
+								"allow": [
+									{
+										"custom_request_handling": [],
+									},
+								],
+								"block":     [],
+								"captcha":   [],
+								"challenge": [],
+								"count":     [],
+							},
+						],
+						"captcha_config":   [],
+						"challenge_config": [],
+						"override_action":  [],
+						"rule_label":       [],
+						"statement": [
+							{
+								"and_statement":        [],
+								"byte_match_statement": [],
+								"geo_match_statement": [
+									{
+										"country_codes": [
+											false,
+										],
+										"forwarded_ip_config": [],
+									},
+								],
+								"ip_set_reference_statement":            [],
+								"label_match_statement":                 [],
+								"managed_rule_group_statement":          [],
+								"not_statement":                         [],
+								"or_statement":                          [],
+								"rate_based_statement":                  [],
+								"regex_match_statement":                 [],
+								"regex_pattern_set_reference_statement": [],
+								"rule_group_reference_statement":        [],
+								"size_constraint_statement":             [],
+								"sqli_match_statement":                  [],
+								"xss_match_statement":                   [],
+							},
+						],
+						"visibility_config": [
+							{},
+						],
+					},
+					{
+						"action":           [],
+						"captcha_config":   [],
+						"challenge_config": [],
+						"override_action": [
+							{
+								"count": [
+									{},
+								],
+								"none": [],
+							},
+						],
+						"rule_label": [],
+						"statement": [
+							{
+								"and_statement":              [],
+								"byte_match_statement":       [],
+								"geo_match_statement":        [],
+								"ip_set_reference_statement": [],
+								"label_match_statement":      [],
+								"managed_rule_group_statement": [
+									{
+										"managed_rule_group_configs": [],
+										"rule_action_override": [
+											{
+												"action_to_use": [
+													{
+														"allow":     [],
+														"block":     [],
+														"captcha":   [],
+														"challenge": [],
+														"count": [
+															{
+																"custom_request_handling": [],
+															},
+														],
+													},
+												],
+											},
+											{
+												"action_to_use": [
+													{
+														"allow":     [],
+														"block":     [],
+														"captcha":   [],
+														"challenge": [],
+														"count": [
+															{
+																"custom_request_handling": [],
+															},
+														],
+													},
+												],
+											},
+										],
+										"scope_down_statement": [
+											{
+												"and_statement":        [],
+												"byte_match_statement": [],
+												"geo_match_statement": [
+													{
+														"country_codes": [
+															false,
+															false,
+														],
+														"forwarded_ip_config": [],
+													},
+												],
+												"ip_set_reference_statement":            [],
+												"label_match_statement":                 [],
+												"not_statement":                         [],
+												"or_statement":                          [],
+												"regex_match_statement":                 [],
+												"regex_pattern_set_reference_statement": [],
+												"size_constraint_statement":             [],
+												"sqli_match_statement":                  [],
+												"xss_match_statement":                   [],
+											},
+										],
+									},
+								],
+								"not_statement":                         [],
+								"or_statement":                          [],
+								"rate_based_statement":                  [],
+								"regex_match_statement":                 [],
+								"regex_pattern_set_reference_statement": [],
+								"rule_group_reference_statement":        [],
+								"size_constraint_statement":             [],
+								"sqli_match_statement":                  [],
+								"xss_match_statement":                   [],
+							},
+						],
+						"visibility_config": [
+							{},
+						],
+					},
+				],
+				"tags":     {},
+				"tags_all": {},
+				"token_domains": [
+					false,
+					false,
+				],
+				"visibility_config": [
+					{},
+				],
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "example",
+		"provider_name":  "registry.terraform.io/hashicorp/aws",
+		"type":           "aws_wafv2_web_acl",
+	},
+}
+
+resource_drift = {}
+
+output_changes = {}
+
+raw = {
+	"complete": true,
+	"configuration": {
+		"provider_config": {
+			"aws": {
+				"expressions": {
+					"region": {
+						"constant_value": "us-east-1",
+					},
+				},
+				"full_name": "registry.terraform.io/hashicorp/aws",
+				"name":      "aws",
+			},
+		},
+		"root_module": {
+			"resources": [
+				{
+					"address": "aws_wafv2_web_acl.example",
+					"expressions": {
+						"default_action": [
+							{
+								"allow": [
+									{},
+								],
+							},
+						],
+						"description": {
+							"constant_value": "Example of a managed rule.",
+						},
+						"name": {
+							"constant_value": "managed-rule-example",
+						},
+						"rule": [
+							{
+								"name": {
+									"constant_value": "rule-1",
+								},
+								"override_action": [
+									{
+										"count": [
+											{},
+										],
+									},
+								],
+								"priority": {
+									"constant_value": 1,
+								},
+								"statement": [
+									{
+										"managed_rule_group_statement": [
+											{
+												"name": {
+													"constant_value": "AWSManagedRulesCommonRuleSet",
+												},
+												"rule_action_override": [
+													{
+														"action_to_use": [
+															{
+																"count": [
+																	{},
+																],
+															},
+														],
+														"name": {
+															"constant_value": "SizeRestrictions_QUERYSTRING",
+														},
+													},
+													{
+														"action_to_use": [
+															{
+																"count": [
+																	{},
+																],
+															},
+														],
+														"name": {
+															"constant_value": "NoUserAgent_HEADER",
+														},
+													},
+												],
+												"scope_down_statement": [
+													{
+														"geo_match_statement": [
+															{
+																"country_codes": {
+																	"constant_value": [
+																		"US",
+																		"NL",
+																	],
+																},
+															},
+														],
+													},
+												],
+												"vendor_name": {
+													"constant_value": "AWS",
+												},
+											},
+										],
+									},
+								],
+								"visibility_config": [
+									{
+										"cloudwatch_metrics_enabled": {
+											"constant_value": false,
+										},
+										"metric_name": {
+											"constant_value": "friendly-rule-metric-name",
+										},
+										"sampled_requests_enabled": {
+											"constant_value": false,
+										},
+									},
+								],
+							},
+							{
+								"action": [
+									{
+										"allow": [
+											{},
+										],
+									},
+								],
+								"name": {
+									"constant_value": "rule-to-exclude-a",
+								},
+								"priority": {
+									"constant_value": 10,
+								},
+								"statement": [
+									{
+										"geo_match_statement": [
+											{
+												"country_codes": {
+													"constant_value": [
+														"US",
+													],
+												},
+											},
+										],
+									},
+								],
+								"visibility_config": [
+									{
+										"cloudwatch_metrics_enabled": {
+											"constant_value": false,
+										},
+										"metric_name": {
+											"constant_value": "friendly-rule-metric-name",
+										},
+										"sampled_requests_enabled": {
+											"constant_value": false,
+										},
+									},
+								],
+							},
+							{
+								"action": [
+									{
+										"allow": [
+											{},
+										],
+									},
+								],
+								"name": {
+									"constant_value": "rule-to-exclude-b",
+								},
+								"priority": {
+									"constant_value": 15,
+								},
+								"statement": [
+									{
+										"geo_match_statement": [
+											{
+												"country_codes": {
+													"constant_value": [
+														"GB",
+													],
+												},
+											},
+										],
+									},
+								],
+								"visibility_config": [
+									{
+										"cloudwatch_metrics_enabled": {
+											"constant_value": false,
+										},
+										"metric_name": {
+											"constant_value": "friendly-rule-metric-name",
+										},
+										"sampled_requests_enabled": {
+											"constant_value": false,
+										},
+									},
+								],
+							},
+						],
+						"scope": {
+							"constant_value": "REGIONAL",
+						},
+						"tags": {
+							"constant_value": {
+								"Tag1": "Value1",
+								"Tag2": "Value2",
+							},
+						},
+						"token_domains": {
+							"constant_value": [
+								"mywebsite.com",
+								"myotherwebsite.com",
+							],
+						},
+						"visibility_config": [
+							{
+								"cloudwatch_metrics_enabled": {
+									"constant_value": false,
+								},
+								"metric_name": {
+									"constant_value": "friendly-metric-name",
+								},
+								"sampled_requests_enabled": {
+									"constant_value": false,
+								},
+							},
+						],
+					},
+					"mode":                "managed",
+					"name":                "example",
+					"provider_config_key": "aws",
+					"schema_version":      0,
+					"type":                "aws_wafv2_web_acl",
+				},
+			],
+		},
+	},
+	"format_version": "1.2",
+	"planned_values": {
+		"root_module": {
+			"resources": [
+				{
+					"address":        "aws_wafv2_web_acl.example",
+					"mode":           "managed",
+					"name":           "example",
+					"provider_name":  "registry.terraform.io/hashicorp/aws",
+					"schema_version": 0,
+					"sensitive_values": {
+						"association_config":   [],
+						"captcha_config":       [],
+						"challenge_config":     [],
+						"custom_response_body": [],
+						"default_action": [
+							{
+								"allow": [
+									{
+										"custom_request_handling": [],
+									},
+								],
+								"block": [],
+							},
+						],
+						"rule": [
+							{
+								"action": [
+									{
+										"allow": [
+											{
+												"custom_request_handling": [],
+											},
+										],
+										"block":     [],
+										"captcha":   [],
+										"challenge": [],
+										"count":     [],
+									},
+								],
+								"captcha_config":   [],
+								"challenge_config": [],
+								"override_action":  [],
+								"rule_label":       [],
+								"statement": [
+									{
+										"and_statement":        [],
+										"byte_match_statement": [],
+										"geo_match_statement": [
+											{
+												"country_codes": [
+													false,
+												],
+												"forwarded_ip_config": [],
+											},
+										],
+										"ip_set_reference_statement":            [],
+										"label_match_statement":                 [],
+										"managed_rule_group_statement":          [],
+										"not_statement":                         [],
+										"or_statement":                          [],
+										"rate_based_statement":                  [],
+										"regex_match_statement":                 [],
+										"regex_pattern_set_reference_statement": [],
+										"rule_group_reference_statement":        [],
+										"size_constraint_statement":             [],
+										"sqli_match_statement":                  [],
+										"xss_match_statement":                   [],
+									},
+								],
+								"visibility_config": [
+									{},
+								],
+							},
+							{
+								"action": [
+									{
+										"allow": [
+											{
+												"custom_request_handling": [],
+											},
+										],
+										"block":     [],
+										"captcha":   [],
+										"challenge": [],
+										"count":     [],
+									},
+								],
+								"captcha_config":   [],
+								"challenge_config": [],
+								"override_action":  [],
+								"rule_label":       [],
+								"statement": [
+									{
+										"and_statement":        [],
+										"byte_match_statement": [],
+										"geo_match_statement": [
+											{
+												"country_codes": [
+													false,
+												],
+												"forwarded_ip_config": [],
+											},
+										],
+										"ip_set_reference_statement":            [],
+										"label_match_statement":                 [],
+										"managed_rule_group_statement":          [],
+										"not_statement":                         [],
+										"or_statement":                          [],
+										"rate_based_statement":                  [],
+										"regex_match_statement":                 [],
+										"regex_pattern_set_reference_statement": [],
+										"rule_group_reference_statement":        [],
+										"size_constraint_statement":             [],
+										"sqli_match_statement":                  [],
+										"xss_match_statement":                   [],
+									},
+								],
+								"visibility_config": [
+									{},
+								],
+							},
+							{
+								"action":           [],
+								"captcha_config":   [],
+								"challenge_config": [],
+								"override_action": [
+									{
+										"count": [
+											{},
+										],
+										"none": [],
+									},
+								],
+								"rule_label": [],
+								"statement": [
+									{
+										"and_statement":              [],
+										"byte_match_statement":       [],
+										"geo_match_statement":        [],
+										"ip_set_reference_statement": [],
+										"label_match_statement":      [],
+										"managed_rule_group_statement": [
+											{
+												"managed_rule_group_configs": [],
+												"rule_action_override": [
+													{
+														"action_to_use": [
+															{
+																"allow":     [],
+																"block":     [],
+																"captcha":   [],
+																"challenge": [],
+																"count": [
+																	{
+																		"custom_request_handling": [],
+																	},
+																],
+															},
+														],
+													},
+													{
+														"action_to_use": [
+															{
+																"allow":     [],
+																"block":     [],
+																"captcha":   [],
+																"challenge": [],
+																"count": [
+																	{
+																		"custom_request_handling": [],
+																	},
+																],
+															},
+														],
+													},
+												],
+												"scope_down_statement": [
+													{
+														"and_statement":        [],
+														"byte_match_statement": [],
+														"geo_match_statement": [
+															{
+																"country_codes": [
+																	false,
+																	false,
+																],
+																"forwarded_ip_config": [],
+															},
+														],
+														"ip_set_reference_statement":            [],
+														"label_match_statement":                 [],
+														"not_statement":                         [],
+														"or_statement":                          [],
+														"regex_match_statement":                 [],
+														"regex_pattern_set_reference_statement": [],
+														"size_constraint_statement":             [],
+														"sqli_match_statement":                  [],
+														"xss_match_statement":                   [],
+													},
+												],
+											},
+										],
+										"not_statement":                         [],
+										"or_statement":                          [],
+										"rate_based_statement":                  [],
+										"regex_match_statement":                 [],
+										"regex_pattern_set_reference_statement": [],
+										"rule_group_reference_statement":        [],
+										"size_constraint_statement":             [],
+										"sqli_match_statement":                  [],
+										"xss_match_statement":                   [],
+									},
+								],
+								"visibility_config": [
+									{},
+								],
+							},
+						],
+						"tags":     {},
+						"tags_all": {},
+						"token_domains": [
+							false,
+							false,
+						],
+						"visibility_config": [
+							{},
+						],
+					},
+					"type": "aws_wafv2_web_acl",
+					"values": {
+						"association_config":   [],
+						"captcha_config":       [],
+						"challenge_config":     [],
+						"custom_response_body": [],
+						"default_action": [
+							{
+								"allow": [
+									{
+										"custom_request_handling": [],
+									},
+								],
+								"block": [],
+							},
+						],
+						"description": "Example of a managed rule.",
+						"name":        "managed-rule-example",
+						"rule": [
+							{
+								"action": [
+									{
+										"allow": [
+											{
+												"custom_request_handling": [],
+											},
+										],
+										"block":     [],
+										"captcha":   [],
+										"challenge": [],
+										"count":     [],
+									},
+								],
+								"captcha_config":   [],
+								"challenge_config": [],
+								"name":             "rule-to-exclude-a",
+								"override_action":  [],
+								"priority":         10,
+								"rule_label":       [],
+								"statement": [
+									{
+										"and_statement":        [],
+										"byte_match_statement": [],
+										"geo_match_statement": [
+											{
+												"country_codes": [
+													"US",
+												],
+												"forwarded_ip_config": [],
+											},
+										],
+										"ip_set_reference_statement":            [],
+										"label_match_statement":                 [],
+										"managed_rule_group_statement":          [],
+										"not_statement":                         [],
+										"or_statement":                          [],
+										"rate_based_statement":                  [],
+										"regex_match_statement":                 [],
+										"regex_pattern_set_reference_statement": [],
+										"rule_group_reference_statement":        [],
+										"size_constraint_statement":             [],
+										"sqli_match_statement":                  [],
+										"xss_match_statement":                   [],
+									},
+								],
+								"visibility_config": [
+									{
+										"cloudwatch_metrics_enabled": false,
+										"metric_name":                "friendly-rule-metric-name",
+										"sampled_requests_enabled":   false,
+									},
+								],
+							},
+							{
+								"action": [
+									{
+										"allow": [
+											{
+												"custom_request_handling": [],
+											},
+										],
+										"block":     [],
+										"captcha":   [],
+										"challenge": [],
+										"count":     [],
+									},
+								],
+								"captcha_config":   [],
+								"challenge_config": [],
+								"name":             "rule-to-exclude-b",
+								"override_action":  [],
+								"priority":         15,
+								"rule_label":       [],
+								"statement": [
+									{
+										"and_statement":        [],
+										"byte_match_statement": [],
+										"geo_match_statement": [
+											{
+												"country_codes": [
+													"GB",
+												],
+												"forwarded_ip_config": [],
+											},
+										],
+										"ip_set_reference_statement":            [],
+										"label_match_statement":                 [],
+										"managed_rule_group_statement":          [],
+										"not_statement":                         [],
+										"or_statement":                          [],
+										"rate_based_statement":                  [],
+										"regex_match_statement":                 [],
+										"regex_pattern_set_reference_statement": [],
+										"rule_group_reference_statement":        [],
+										"size_constraint_statement":             [],
+										"sqli_match_statement":                  [],
+										"xss_match_statement":                   [],
+									},
+								],
+								"visibility_config": [
+									{
+										"cloudwatch_metrics_enabled": false,
+										"metric_name":                "friendly-rule-metric-name",
+										"sampled_requests_enabled":   false,
+									},
+								],
+							},
+							{
+								"action":           [],
+								"captcha_config":   [],
+								"challenge_config": [],
+								"name":             "rule-1",
+								"override_action": [
+									{
+										"count": [
+											{},
+										],
+										"none": [],
+									},
+								],
+								"priority":   1,
+								"rule_label": [],
+								"statement": [
+									{
+										"and_statement":              [],
+										"byte_match_statement":       [],
+										"geo_match_statement":        [],
+										"ip_set_reference_statement": [],
+										"label_match_statement":      [],
+										"managed_rule_group_statement": [
+											{
+												"managed_rule_group_configs": [],
+												"name": "AWSManagedRulesCommonRuleSet",
+												"rule_action_override": [
+													{
+														"action_to_use": [
+															{
+																"allow":     [],
+																"block":     [],
+																"captcha":   [],
+																"challenge": [],
+																"count": [
+																	{
+																		"custom_request_handling": [],
+																	},
+																],
+															},
+														],
+														"name": "SizeRestrictions_QUERYSTRING",
+													},
+													{
+														"action_to_use": [
+															{
+																"allow":     [],
+																"block":     [],
+																"captcha":   [],
+																"challenge": [],
+																"count": [
+																	{
+																		"custom_request_handling": [],
+																	},
+																],
+															},
+														],
+														"name": "NoUserAgent_HEADER",
+													},
+												],
+												"scope_down_statement": [
+													{
+														"and_statement":        [],
+														"byte_match_statement": [],
+														"geo_match_statement": [
+															{
+																"country_codes": [
+																	"US",
+																	"NL",
+																],
+																"forwarded_ip_config": [],
+															},
+														],
+														"ip_set_reference_statement":            [],
+														"label_match_statement":                 [],
+														"not_statement":                         [],
+														"or_statement":                          [],
+														"regex_match_statement":                 [],
+														"regex_pattern_set_reference_statement": [],
+														"size_constraint_statement":             [],
+														"sqli_match_statement":                  [],
+														"xss_match_statement":                   [],
+													},
+												],
+												"vendor_name": "AWS",
+												"version":     "",
+											},
+										],
+										"not_statement":                         [],
+										"or_statement":                          [],
+										"rate_based_statement":                  [],
+										"regex_match_statement":                 [],
+										"regex_pattern_set_reference_statement": [],
+										"rule_group_reference_statement":        [],
+										"size_constraint_statement":             [],
+										"sqli_match_statement":                  [],
+										"xss_match_statement":                   [],
+									},
+								],
+								"visibility_config": [
+									{
+										"cloudwatch_metrics_enabled": false,
+										"metric_name":                "friendly-rule-metric-name",
+										"sampled_requests_enabled":   false,
+									},
+								],
+							},
+						],
+						"rule_json": null,
+						"scope":     "REGIONAL",
+						"tags": {
+							"Tag1": "Value1",
+							"Tag2": "Value2",
+						},
+						"tags_all": {
+							"Tag1": "Value1",
+							"Tag2": "Value2",
+						},
+						"token_domains": [
+							"myotherwebsite.com",
+							"mywebsite.com",
+						],
+						"visibility_config": [
+							{
+								"cloudwatch_metrics_enabled": false,
+								"metric_name":                "friendly-metric-name",
+								"sampled_requests_enabled":   false,
+							},
+						],
+					},
+				},
+			],
+		},
+	},
+	"resource_changes": [
+		{
+			"address": "aws_wafv2_web_acl.example",
+			"change": {
+				"actions": [
+					"create",
+				],
+				"after": {
+					"association_config":   [],
+					"captcha_config":       [],
+					"challenge_config":     [],
+					"custom_response_body": [],
+					"default_action": [
+						{
+							"allow": [
+								{
+									"custom_request_handling": [],
+								},
+							],
+							"block": [],
+						},
+					],
+					"description": "Example of a managed rule.",
+					"name":        "managed-rule-example",
+					"rule": [
+						{
+							"action": [
+								{
+									"allow": [
+										{
+											"custom_request_handling": [],
+										},
+									],
+									"block":     [],
+									"captcha":   [],
+									"challenge": [],
+									"count":     [],
+								},
+							],
+							"captcha_config":   [],
+							"challenge_config": [],
+							"name":             "rule-to-exclude-a",
+							"override_action":  [],
+							"priority":         10,
+							"rule_label":       [],
+							"statement": [
+								{
+									"and_statement":        [],
+									"byte_match_statement": [],
+									"geo_match_statement": [
+										{
+											"country_codes": [
+												"US",
+											],
+											"forwarded_ip_config": [],
+										},
+									],
+									"ip_set_reference_statement":            [],
+									"label_match_statement":                 [],
+									"managed_rule_group_statement":          [],
+									"not_statement":                         [],
+									"or_statement":                          [],
+									"rate_based_statement":                  [],
+									"regex_match_statement":                 [],
+									"regex_pattern_set_reference_statement": [],
+									"rule_group_reference_statement":        [],
+									"size_constraint_statement":             [],
+									"sqli_match_statement":                  [],
+									"xss_match_statement":                   [],
+								},
+							],
+							"visibility_config": [
+								{
+									"cloudwatch_metrics_enabled": false,
+									"metric_name":                "friendly-rule-metric-name",
+									"sampled_requests_enabled":   false,
+								},
+							],
+						},
+						{
+							"action": [
+								{
+									"allow": [
+										{
+											"custom_request_handling": [],
+										},
+									],
+									"block":     [],
+									"captcha":   [],
+									"challenge": [],
+									"count":     [],
+								},
+							],
+							"captcha_config":   [],
+							"challenge_config": [],
+							"name":             "rule-to-exclude-b",
+							"override_action":  [],
+							"priority":         15,
+							"rule_label":       [],
+							"statement": [
+								{
+									"and_statement":        [],
+									"byte_match_statement": [],
+									"geo_match_statement": [
+										{
+											"country_codes": [
+												"GB",
+											],
+											"forwarded_ip_config": [],
+										},
+									],
+									"ip_set_reference_statement":            [],
+									"label_match_statement":                 [],
+									"managed_rule_group_statement":          [],
+									"not_statement":                         [],
+									"or_statement":                          [],
+									"rate_based_statement":                  [],
+									"regex_match_statement":                 [],
+									"regex_pattern_set_reference_statement": [],
+									"rule_group_reference_statement":        [],
+									"size_constraint_statement":             [],
+									"sqli_match_statement":                  [],
+									"xss_match_statement":                   [],
+								},
+							],
+							"visibility_config": [
+								{
+									"cloudwatch_metrics_enabled": false,
+									"metric_name":                "friendly-rule-metric-name",
+									"sampled_requests_enabled":   false,
+								},
+							],
+						},
+						{
+							"action":           [],
+							"captcha_config":   [],
+							"challenge_config": [],
+							"name":             "rule-1",
+							"override_action": [
+								{
+									"count": [
+										{},
+									],
+									"none": [],
+								},
+							],
+							"priority":   1,
+							"rule_label": [],
+							"statement": [
+								{
+									"and_statement":              [],
+									"byte_match_statement":       [],
+									"geo_match_statement":        [],
+									"ip_set_reference_statement": [],
+									"label_match_statement":      [],
+									"managed_rule_group_statement": [
+										{
+											"managed_rule_group_configs": [],
+											"name": "AWSManagedRulesCommonRuleSet",
+											"rule_action_override": [
+												{
+													"action_to_use": [
+														{
+															"allow":     [],
+															"block":     [],
+															"captcha":   [],
+															"challenge": [],
+															"count": [
+																{
+																	"custom_request_handling": [],
+																},
+															],
+														},
+													],
+													"name": "SizeRestrictions_QUERYSTRING",
+												},
+												{
+													"action_to_use": [
+														{
+															"allow":     [],
+															"block":     [],
+															"captcha":   [],
+															"challenge": [],
+															"count": [
+																{
+																	"custom_request_handling": [],
+																},
+															],
+														},
+													],
+													"name": "NoUserAgent_HEADER",
+												},
+											],
+											"scope_down_statement": [
+												{
+													"and_statement":        [],
+													"byte_match_statement": [],
+													"geo_match_statement": [
+														{
+															"country_codes": [
+																"US",
+																"NL",
+															],
+															"forwarded_ip_config": [],
+														},
+													],
+													"ip_set_reference_statement":            [],
+													"label_match_statement":                 [],
+													"not_statement":                         [],
+													"or_statement":                          [],
+													"regex_match_statement":                 [],
+													"regex_pattern_set_reference_statement": [],
+													"size_constraint_statement":             [],
+													"sqli_match_statement":                  [],
+													"xss_match_statement":                   [],
+												},
+											],
+											"vendor_name": "AWS",
+											"version":     "",
+										},
+									],
+									"not_statement":                         [],
+									"or_statement":                          [],
+									"rate_based_statement":                  [],
+									"regex_match_statement":                 [],
+									"regex_pattern_set_reference_statement": [],
+									"rule_group_reference_statement":        [],
+									"size_constraint_statement":             [],
+									"sqli_match_statement":                  [],
+									"xss_match_statement":                   [],
+								},
+							],
+							"visibility_config": [
+								{
+									"cloudwatch_metrics_enabled": false,
+									"metric_name":                "friendly-rule-metric-name",
+									"sampled_requests_enabled":   false,
+								},
+							],
+						},
+					],
+					"rule_json": null,
+					"scope":     "REGIONAL",
+					"tags": {
+						"Tag1": "Value1",
+						"Tag2": "Value2",
+					},
+					"tags_all": {
+						"Tag1": "Value1",
+						"Tag2": "Value2",
+					},
+					"token_domains": [
+						"myotherwebsite.com",
+						"mywebsite.com",
+					],
+					"visibility_config": [
+						{
+							"cloudwatch_metrics_enabled": false,
+							"metric_name":                "friendly-metric-name",
+							"sampled_requests_enabled":   false,
+						},
+					],
+				},
+				"after_sensitive": {
+					"association_config":   [],
+					"captcha_config":       [],
+					"challenge_config":     [],
+					"custom_response_body": [],
+					"default_action": [
+						{
+							"allow": [
+								{
+									"custom_request_handling": [],
+								},
+							],
+							"block": [],
+						},
+					],
+					"rule": [
+						{
+							"action": [
+								{
+									"allow": [
+										{
+											"custom_request_handling": [],
+										},
+									],
+									"block":     [],
+									"captcha":   [],
+									"challenge": [],
+									"count":     [],
+								},
+							],
+							"captcha_config":   [],
+							"challenge_config": [],
+							"override_action":  [],
+							"rule_label":       [],
+							"statement": [
+								{
+									"and_statement":        [],
+									"byte_match_statement": [],
+									"geo_match_statement": [
+										{
+											"country_codes": [
+												false,
+											],
+											"forwarded_ip_config": [],
+										},
+									],
+									"ip_set_reference_statement":            [],
+									"label_match_statement":                 [],
+									"managed_rule_group_statement":          [],
+									"not_statement":                         [],
+									"or_statement":                          [],
+									"rate_based_statement":                  [],
+									"regex_match_statement":                 [],
+									"regex_pattern_set_reference_statement": [],
+									"rule_group_reference_statement":        [],
+									"size_constraint_statement":             [],
+									"sqli_match_statement":                  [],
+									"xss_match_statement":                   [],
+								},
+							],
+							"visibility_config": [
+								{},
+							],
+						},
+						{
+							"action": [
+								{
+									"allow": [
+										{
+											"custom_request_handling": [],
+										},
+									],
+									"block":     [],
+									"captcha":   [],
+									"challenge": [],
+									"count":     [],
+								},
+							],
+							"captcha_config":   [],
+							"challenge_config": [],
+							"override_action":  [],
+							"rule_label":       [],
+							"statement": [
+								{
+									"and_statement":        [],
+									"byte_match_statement": [],
+									"geo_match_statement": [
+										{
+											"country_codes": [
+												false,
+											],
+											"forwarded_ip_config": [],
+										},
+									],
+									"ip_set_reference_statement":            [],
+									"label_match_statement":                 [],
+									"managed_rule_group_statement":          [],
+									"not_statement":                         [],
+									"or_statement":                          [],
+									"rate_based_statement":                  [],
+									"regex_match_statement":                 [],
+									"regex_pattern_set_reference_statement": [],
+									"rule_group_reference_statement":        [],
+									"size_constraint_statement":             [],
+									"sqli_match_statement":                  [],
+									"xss_match_statement":                   [],
+								},
+							],
+							"visibility_config": [
+								{},
+							],
+						},
+						{
+							"action":           [],
+							"captcha_config":   [],
+							"challenge_config": [],
+							"override_action": [
+								{
+									"count": [
+										{},
+									],
+									"none": [],
+								},
+							],
+							"rule_label": [],
+							"statement": [
+								{
+									"and_statement":              [],
+									"byte_match_statement":       [],
+									"geo_match_statement":        [],
+									"ip_set_reference_statement": [],
+									"label_match_statement":      [],
+									"managed_rule_group_statement": [
+										{
+											"managed_rule_group_configs": [],
+											"rule_action_override": [
+												{
+													"action_to_use": [
+														{
+															"allow":     [],
+															"block":     [],
+															"captcha":   [],
+															"challenge": [],
+															"count": [
+																{
+																	"custom_request_handling": [],
+																},
+															],
+														},
+													],
+												},
+												{
+													"action_to_use": [
+														{
+															"allow":     [],
+															"block":     [],
+															"captcha":   [],
+															"challenge": [],
+															"count": [
+																{
+																	"custom_request_handling": [],
+																},
+															],
+														},
+													],
+												},
+											],
+											"scope_down_statement": [
+												{
+													"and_statement":        [],
+													"byte_match_statement": [],
+													"geo_match_statement": [
+														{
+															"country_codes": [
+																false,
+																false,
+															],
+															"forwarded_ip_config": [],
+														},
+													],
+													"ip_set_reference_statement":            [],
+													"label_match_statement":                 [],
+													"not_statement":                         [],
+													"or_statement":                          [],
+													"regex_match_statement":                 [],
+													"regex_pattern_set_reference_statement": [],
+													"size_constraint_statement":             [],
+													"sqli_match_statement":                  [],
+													"xss_match_statement":                   [],
+												},
+											],
+										},
+									],
+									"not_statement":                         [],
+									"or_statement":                          [],
+									"rate_based_statement":                  [],
+									"regex_match_statement":                 [],
+									"regex_pattern_set_reference_statement": [],
+									"rule_group_reference_statement":        [],
+									"size_constraint_statement":             [],
+									"sqli_match_statement":                  [],
+									"xss_match_statement":                   [],
+								},
+							],
+							"visibility_config": [
+								{},
+							],
+						},
+					],
+					"tags":     {},
+					"tags_all": {},
+					"token_domains": [
+						false,
+						false,
+					],
+					"visibility_config": [
+						{},
+					],
+				},
+				"after_unknown": {
+					"application_integration_url": true,
+					"arn":                  true,
+					"association_config":   [],
+					"capacity":             true,
+					"captcha_config":       [],
+					"challenge_config":     [],
+					"custom_response_body": [],
+					"default_action": [
+						{
+							"allow": [
+								{
+									"custom_request_handling": [],
+								},
+							],
+							"block": [],
+						},
+					],
+					"id":          true,
+					"lock_token":  true,
+					"name_prefix": true,
+					"rule": [
+						{
+							"action": [
+								{
+									"allow": [
+										{
+											"custom_request_handling": [],
+										},
+									],
+									"block":     [],
+									"captcha":   [],
+									"challenge": [],
+									"count":     [],
+								},
+							],
+							"captcha_config":   [],
+							"challenge_config": [],
+							"override_action":  [],
+							"rule_label":       [],
+							"statement": [
+								{
+									"and_statement":        [],
+									"byte_match_statement": [],
+									"geo_match_statement": [
+										{
+											"country_codes": [
+												false,
+											],
+											"forwarded_ip_config": [],
+										},
+									],
+									"ip_set_reference_statement":            [],
+									"label_match_statement":                 [],
+									"managed_rule_group_statement":          [],
+									"not_statement":                         [],
+									"or_statement":                          [],
+									"rate_based_statement":                  [],
+									"regex_match_statement":                 [],
+									"regex_pattern_set_reference_statement": [],
+									"rule_group_reference_statement":        [],
+									"size_constraint_statement":             [],
+									"sqli_match_statement":                  [],
+									"xss_match_statement":                   [],
+								},
+							],
+							"visibility_config": [
+								{},
+							],
+						},
+						{
+							"action": [
+								{
+									"allow": [
+										{
+											"custom_request_handling": [],
+										},
+									],
+									"block":     [],
+									"captcha":   [],
+									"challenge": [],
+									"count":     [],
+								},
+							],
+							"captcha_config":   [],
+							"challenge_config": [],
+							"override_action":  [],
+							"rule_label":       [],
+							"statement": [
+								{
+									"and_statement":        [],
+									"byte_match_statement": [],
+									"geo_match_statement": [
+										{
+											"country_codes": [
+												false,
+											],
+											"forwarded_ip_config": [],
+										},
+									],
+									"ip_set_reference_statement":            [],
+									"label_match_statement":                 [],
+									"managed_rule_group_statement":          [],
+									"not_statement":                         [],
+									"or_statement":                          [],
+									"rate_based_statement":                  [],
+									"regex_match_statement":                 [],
+									"regex_pattern_set_reference_statement": [],
+									"rule_group_reference_statement":        [],
+									"size_constraint_statement":             [],
+									"sqli_match_statement":                  [],
+									"xss_match_statement":                   [],
+								},
+							],
+							"visibility_config": [
+								{},
+							],
+						},
+						{
+							"action":           [],
+							"captcha_config":   [],
+							"challenge_config": [],
+							"override_action": [
+								{
+									"count": [
+										{},
+									],
+									"none": [],
+								},
+							],
+							"rule_label": [],
+							"statement": [
+								{
+									"and_statement":              [],
+									"byte_match_statement":       [],
+									"geo_match_statement":        [],
+									"ip_set_reference_statement": [],
+									"label_match_statement":      [],
+									"managed_rule_group_statement": [
+										{
+											"managed_rule_group_configs": [],
+											"rule_action_override": [
+												{
+													"action_to_use": [
+														{
+															"allow":     [],
+															"block":     [],
+															"captcha":   [],
+															"challenge": [],
+															"count": [
+																{
+																	"custom_request_handling": [],
+																},
+															],
+														},
+													],
+												},
+												{
+													"action_to_use": [
+														{
+															"allow":     [],
+															"block":     [],
+															"captcha":   [],
+															"challenge": [],
+															"count": [
+																{
+																	"custom_request_handling": [],
+																},
+															],
+														},
+													],
+												},
+											],
+											"scope_down_statement": [
+												{
+													"and_statement":        [],
+													"byte_match_statement": [],
+													"geo_match_statement": [
+														{
+															"country_codes": [
+																false,
+																false,
+															],
+															"forwarded_ip_config": [],
+														},
+													],
+													"ip_set_reference_statement":            [],
+													"label_match_statement":                 [],
+													"not_statement":                         [],
+													"or_statement":                          [],
+													"regex_match_statement":                 [],
+													"regex_pattern_set_reference_statement": [],
+													"size_constraint_statement":             [],
+													"sqli_match_statement":                  [],
+													"xss_match_statement":                   [],
+												},
+											],
+										},
+									],
+									"not_statement":                         [],
+									"or_statement":                          [],
+									"rate_based_statement":                  [],
+									"regex_match_statement":                 [],
+									"regex_pattern_set_reference_statement": [],
+									"rule_group_reference_statement":        [],
+									"size_constraint_statement":             [],
+									"sqli_match_statement":                  [],
+									"xss_match_statement":                   [],
+								},
+							],
+							"visibility_config": [
+								{},
+							],
+						},
+					],
+					"tags":     {},
+					"tags_all": {},
+					"token_domains": [
+						false,
+						false,
+					],
+					"visibility_config": [
+						{},
+					],
+				},
+				"before":           null,
+				"before_sensitive": false,
+			},
+			"mode":          "managed",
+			"name":          "example",
+			"provider_name": "registry.terraform.io/hashicorp/aws",
+			"type":          "aws_wafv2_web_acl",
+		},
+	],
+	"terraform_version": "1.10.2",
+	"timestamp":         "2025-04-08T05:40:09Z",
+}

--- a/policies/test/wafv2-webacl-not-empty/mocks/policy-success-rules-are-present/mock-tfplan-v2.sentinel
+++ b/policies/test/wafv2-webacl-not-empty/mocks/policy-success-rules-are-present/mock-tfplan-v2.sentinel
@@ -1,0 +1,1329 @@
+terraform_version = "1.10.2"
+
+planned_values = {
+	"outputs": {},
+	"resources": {
+		"aws_wafv2_web_acl.example": {
+			"address":        "aws_wafv2_web_acl.example",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "example",
+			"provider_name":  "registry.terraform.io/hashicorp/aws",
+			"tainted":        false,
+			"type":           "aws_wafv2_web_acl",
+			"values": {
+				"association_config":   [],
+				"captcha_config":       [],
+				"challenge_config":     [],
+				"custom_response_body": [],
+				"default_action": [
+					{
+						"allow": [
+							{
+								"custom_request_handling": [],
+							},
+						],
+						"block": [],
+					},
+				],
+				"description": "Example of a managed rule.",
+				"name":        "managed-rule-example",
+				"rule": [
+					{
+						"action":           [],
+						"captcha_config":   [],
+						"challenge_config": [],
+						"name":             "rule-1",
+						"override_action": [
+							{
+								"count": [
+									{},
+								],
+								"none": [],
+							},
+						],
+						"priority":   1,
+						"rule_label": [],
+						"statement": [
+							{
+								"and_statement":              [],
+								"byte_match_statement":       [],
+								"geo_match_statement":        [],
+								"ip_set_reference_statement": [],
+								"label_match_statement":      [],
+								"managed_rule_group_statement": [
+									{
+										"managed_rule_group_configs": [],
+										"name": "AWSManagedRulesCommonRuleSet",
+										"rule_action_override": [
+											{
+												"action_to_use": [
+													{
+														"allow":     [],
+														"block":     [],
+														"captcha":   [],
+														"challenge": [],
+														"count": [
+															{
+																"custom_request_handling": [],
+															},
+														],
+													},
+												],
+												"name": "SizeRestrictions_QUERYSTRING",
+											},
+											{
+												"action_to_use": [
+													{
+														"allow":     [],
+														"block":     [],
+														"captcha":   [],
+														"challenge": [],
+														"count": [
+															{
+																"custom_request_handling": [],
+															},
+														],
+													},
+												],
+												"name": "NoUserAgent_HEADER",
+											},
+										],
+										"scope_down_statement": [
+											{
+												"and_statement":        [],
+												"byte_match_statement": [],
+												"geo_match_statement": [
+													{
+														"country_codes": [
+															"US",
+															"NL",
+														],
+														"forwarded_ip_config": [],
+													},
+												],
+												"ip_set_reference_statement":            [],
+												"label_match_statement":                 [],
+												"not_statement":                         [],
+												"or_statement":                          [],
+												"regex_match_statement":                 [],
+												"regex_pattern_set_reference_statement": [],
+												"size_constraint_statement":             [],
+												"sqli_match_statement":                  [],
+												"xss_match_statement":                   [],
+											},
+										],
+										"vendor_name": "AWS",
+										"version":     "",
+									},
+								],
+								"not_statement":                         [],
+								"or_statement":                          [],
+								"rate_based_statement":                  [],
+								"regex_match_statement":                 [],
+								"regex_pattern_set_reference_statement": [],
+								"rule_group_reference_statement":        [],
+								"size_constraint_statement":             [],
+								"sqli_match_statement":                  [],
+								"xss_match_statement":                   [],
+							},
+						],
+						"visibility_config": [
+							{
+								"cloudwatch_metrics_enabled": false,
+								"metric_name":                "friendly-rule-metric-name",
+								"sampled_requests_enabled":   false,
+							},
+						],
+					},
+				],
+				"rule_json": null,
+				"scope":     "REGIONAL",
+				"tags": {
+					"Tag1": "Value1",
+					"Tag2": "Value2",
+				},
+				"tags_all": {
+					"Tag1": "Value1",
+					"Tag2": "Value2",
+				},
+				"token_domains": [
+					"myotherwebsite.com",
+					"mywebsite.com",
+				],
+				"visibility_config": [
+					{
+						"cloudwatch_metrics_enabled": false,
+						"metric_name":                "friendly-metric-name",
+						"sampled_requests_enabled":   false,
+					},
+				],
+			},
+		},
+	},
+}
+
+variables = {}
+
+resource_changes = {
+	"aws_wafv2_web_acl.example": {
+		"address": "aws_wafv2_web_acl.example",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"association_config":   [],
+				"captcha_config":       [],
+				"challenge_config":     [],
+				"custom_response_body": [],
+				"default_action": [
+					{
+						"allow": [
+							{
+								"custom_request_handling": [],
+							},
+						],
+						"block": [],
+					},
+				],
+				"description": "Example of a managed rule.",
+				"name":        "managed-rule-example",
+				"rule": [
+					{
+						"action":           [],
+						"captcha_config":   [],
+						"challenge_config": [],
+						"name":             "rule-1",
+						"override_action": [
+							{
+								"count": [
+									{},
+								],
+								"none": [],
+							},
+						],
+						"priority":   1,
+						"rule_label": [],
+						"statement": [
+							{
+								"and_statement":              [],
+								"byte_match_statement":       [],
+								"geo_match_statement":        [],
+								"ip_set_reference_statement": [],
+								"label_match_statement":      [],
+								"managed_rule_group_statement": [
+									{
+										"managed_rule_group_configs": [],
+										"name": "AWSManagedRulesCommonRuleSet",
+										"rule_action_override": [
+											{
+												"action_to_use": [
+													{
+														"allow":     [],
+														"block":     [],
+														"captcha":   [],
+														"challenge": [],
+														"count": [
+															{
+																"custom_request_handling": [],
+															},
+														],
+													},
+												],
+												"name": "SizeRestrictions_QUERYSTRING",
+											},
+											{
+												"action_to_use": [
+													{
+														"allow":     [],
+														"block":     [],
+														"captcha":   [],
+														"challenge": [],
+														"count": [
+															{
+																"custom_request_handling": [],
+															},
+														],
+													},
+												],
+												"name": "NoUserAgent_HEADER",
+											},
+										],
+										"scope_down_statement": [
+											{
+												"and_statement":        [],
+												"byte_match_statement": [],
+												"geo_match_statement": [
+													{
+														"country_codes": [
+															"US",
+															"NL",
+														],
+														"forwarded_ip_config": [],
+													},
+												],
+												"ip_set_reference_statement":            [],
+												"label_match_statement":                 [],
+												"not_statement":                         [],
+												"or_statement":                          [],
+												"regex_match_statement":                 [],
+												"regex_pattern_set_reference_statement": [],
+												"size_constraint_statement":             [],
+												"sqli_match_statement":                  [],
+												"xss_match_statement":                   [],
+											},
+										],
+										"vendor_name": "AWS",
+										"version":     "",
+									},
+								],
+								"not_statement":                         [],
+								"or_statement":                          [],
+								"rate_based_statement":                  [],
+								"regex_match_statement":                 [],
+								"regex_pattern_set_reference_statement": [],
+								"rule_group_reference_statement":        [],
+								"size_constraint_statement":             [],
+								"sqli_match_statement":                  [],
+								"xss_match_statement":                   [],
+							},
+						],
+						"visibility_config": [
+							{
+								"cloudwatch_metrics_enabled": false,
+								"metric_name":                "friendly-rule-metric-name",
+								"sampled_requests_enabled":   false,
+							},
+						],
+					},
+				],
+				"rule_json": null,
+				"scope":     "REGIONAL",
+				"tags": {
+					"Tag1": "Value1",
+					"Tag2": "Value2",
+				},
+				"tags_all": {
+					"Tag1": "Value1",
+					"Tag2": "Value2",
+				},
+				"token_domains": [
+					"myotherwebsite.com",
+					"mywebsite.com",
+				],
+				"visibility_config": [
+					{
+						"cloudwatch_metrics_enabled": false,
+						"metric_name":                "friendly-metric-name",
+						"sampled_requests_enabled":   false,
+					},
+				],
+			},
+			"after_unknown": {
+				"application_integration_url": true,
+				"arn":                  true,
+				"association_config":   [],
+				"capacity":             true,
+				"captcha_config":       [],
+				"challenge_config":     [],
+				"custom_response_body": [],
+				"default_action": [
+					{
+						"allow": [
+							{
+								"custom_request_handling": [],
+							},
+						],
+						"block": [],
+					},
+				],
+				"id":          true,
+				"lock_token":  true,
+				"name_prefix": true,
+				"rule": [
+					{
+						"action":           [],
+						"captcha_config":   [],
+						"challenge_config": [],
+						"override_action": [
+							{
+								"count": [
+									{},
+								],
+								"none": [],
+							},
+						],
+						"rule_label": [],
+						"statement": [
+							{
+								"and_statement":              [],
+								"byte_match_statement":       [],
+								"geo_match_statement":        [],
+								"ip_set_reference_statement": [],
+								"label_match_statement":      [],
+								"managed_rule_group_statement": [
+									{
+										"managed_rule_group_configs": [],
+										"rule_action_override": [
+											{
+												"action_to_use": [
+													{
+														"allow":     [],
+														"block":     [],
+														"captcha":   [],
+														"challenge": [],
+														"count": [
+															{
+																"custom_request_handling": [],
+															},
+														],
+													},
+												],
+											},
+											{
+												"action_to_use": [
+													{
+														"allow":     [],
+														"block":     [],
+														"captcha":   [],
+														"challenge": [],
+														"count": [
+															{
+																"custom_request_handling": [],
+															},
+														],
+													},
+												],
+											},
+										],
+										"scope_down_statement": [
+											{
+												"and_statement":        [],
+												"byte_match_statement": [],
+												"geo_match_statement": [
+													{
+														"country_codes": [
+															false,
+															false,
+														],
+														"forwarded_ip_config": [],
+													},
+												],
+												"ip_set_reference_statement":            [],
+												"label_match_statement":                 [],
+												"not_statement":                         [],
+												"or_statement":                          [],
+												"regex_match_statement":                 [],
+												"regex_pattern_set_reference_statement": [],
+												"size_constraint_statement":             [],
+												"sqli_match_statement":                  [],
+												"xss_match_statement":                   [],
+											},
+										],
+									},
+								],
+								"not_statement":                         [],
+								"or_statement":                          [],
+								"rate_based_statement":                  [],
+								"regex_match_statement":                 [],
+								"regex_pattern_set_reference_statement": [],
+								"rule_group_reference_statement":        [],
+								"size_constraint_statement":             [],
+								"sqli_match_statement":                  [],
+								"xss_match_statement":                   [],
+							},
+						],
+						"visibility_config": [
+							{},
+						],
+					},
+				],
+				"tags":     {},
+				"tags_all": {},
+				"token_domains": [
+					false,
+					false,
+				],
+				"visibility_config": [
+					{},
+				],
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "example",
+		"provider_name":  "registry.terraform.io/hashicorp/aws",
+		"type":           "aws_wafv2_web_acl",
+	},
+}
+
+resource_drift = {}
+
+output_changes = {}
+
+raw = {
+	"complete": true,
+	"configuration": {
+		"provider_config": {
+			"aws": {
+				"expressions": {
+					"region": {
+						"constant_value": "us-east-1",
+					},
+				},
+				"full_name": "registry.terraform.io/hashicorp/aws",
+				"name":      "aws",
+			},
+		},
+		"root_module": {
+			"resources": [
+				{
+					"address": "aws_wafv2_web_acl.example",
+					"expressions": {
+						"default_action": [
+							{
+								"allow": [
+									{},
+								],
+							},
+						],
+						"description": {
+							"constant_value": "Example of a managed rule.",
+						},
+						"name": {
+							"constant_value": "managed-rule-example",
+						},
+						"rule": [
+							{
+								"name": {
+									"constant_value": "rule-1",
+								},
+								"override_action": [
+									{
+										"count": [
+											{},
+										],
+									},
+								],
+								"priority": {
+									"constant_value": 1,
+								},
+								"statement": [
+									{
+										"managed_rule_group_statement": [
+											{
+												"name": {
+													"constant_value": "AWSManagedRulesCommonRuleSet",
+												},
+												"rule_action_override": [
+													{
+														"action_to_use": [
+															{
+																"count": [
+																	{},
+																],
+															},
+														],
+														"name": {
+															"constant_value": "SizeRestrictions_QUERYSTRING",
+														},
+													},
+													{
+														"action_to_use": [
+															{
+																"count": [
+																	{},
+																],
+															},
+														],
+														"name": {
+															"constant_value": "NoUserAgent_HEADER",
+														},
+													},
+												],
+												"scope_down_statement": [
+													{
+														"geo_match_statement": [
+															{
+																"country_codes": {
+																	"constant_value": [
+																		"US",
+																		"NL",
+																	],
+																},
+															},
+														],
+													},
+												],
+												"vendor_name": {
+													"constant_value": "AWS",
+												},
+											},
+										],
+									},
+								],
+								"visibility_config": [
+									{
+										"cloudwatch_metrics_enabled": {
+											"constant_value": false,
+										},
+										"metric_name": {
+											"constant_value": "friendly-rule-metric-name",
+										},
+										"sampled_requests_enabled": {
+											"constant_value": false,
+										},
+									},
+								],
+							},
+						],
+						"scope": {
+							"constant_value": "REGIONAL",
+						},
+						"tags": {
+							"constant_value": {
+								"Tag1": "Value1",
+								"Tag2": "Value2",
+							},
+						},
+						"token_domains": {
+							"constant_value": [
+								"mywebsite.com",
+								"myotherwebsite.com",
+							],
+						},
+						"visibility_config": [
+							{
+								"cloudwatch_metrics_enabled": {
+									"constant_value": false,
+								},
+								"metric_name": {
+									"constant_value": "friendly-metric-name",
+								},
+								"sampled_requests_enabled": {
+									"constant_value": false,
+								},
+							},
+						],
+					},
+					"mode":                "managed",
+					"name":                "example",
+					"provider_config_key": "aws",
+					"schema_version":      0,
+					"type":                "aws_wafv2_web_acl",
+				},
+			],
+		},
+	},
+	"format_version": "1.2",
+	"planned_values": {
+		"root_module": {
+			"resources": [
+				{
+					"address":        "aws_wafv2_web_acl.example",
+					"mode":           "managed",
+					"name":           "example",
+					"provider_name":  "registry.terraform.io/hashicorp/aws",
+					"schema_version": 0,
+					"sensitive_values": {
+						"association_config":   [],
+						"captcha_config":       [],
+						"challenge_config":     [],
+						"custom_response_body": [],
+						"default_action": [
+							{
+								"allow": [
+									{
+										"custom_request_handling": [],
+									},
+								],
+								"block": [],
+							},
+						],
+						"rule": [
+							{
+								"action":           [],
+								"captcha_config":   [],
+								"challenge_config": [],
+								"override_action": [
+									{
+										"count": [
+											{},
+										],
+										"none": [],
+									},
+								],
+								"rule_label": [],
+								"statement": [
+									{
+										"and_statement":              [],
+										"byte_match_statement":       [],
+										"geo_match_statement":        [],
+										"ip_set_reference_statement": [],
+										"label_match_statement":      [],
+										"managed_rule_group_statement": [
+											{
+												"managed_rule_group_configs": [],
+												"rule_action_override": [
+													{
+														"action_to_use": [
+															{
+																"allow":     [],
+																"block":     [],
+																"captcha":   [],
+																"challenge": [],
+																"count": [
+																	{
+																		"custom_request_handling": [],
+																	},
+																],
+															},
+														],
+													},
+													{
+														"action_to_use": [
+															{
+																"allow":     [],
+																"block":     [],
+																"captcha":   [],
+																"challenge": [],
+																"count": [
+																	{
+																		"custom_request_handling": [],
+																	},
+																],
+															},
+														],
+													},
+												],
+												"scope_down_statement": [
+													{
+														"and_statement":        [],
+														"byte_match_statement": [],
+														"geo_match_statement": [
+															{
+																"country_codes": [
+																	false,
+																	false,
+																],
+																"forwarded_ip_config": [],
+															},
+														],
+														"ip_set_reference_statement":            [],
+														"label_match_statement":                 [],
+														"not_statement":                         [],
+														"or_statement":                          [],
+														"regex_match_statement":                 [],
+														"regex_pattern_set_reference_statement": [],
+														"size_constraint_statement":             [],
+														"sqli_match_statement":                  [],
+														"xss_match_statement":                   [],
+													},
+												],
+											},
+										],
+										"not_statement":                         [],
+										"or_statement":                          [],
+										"rate_based_statement":                  [],
+										"regex_match_statement":                 [],
+										"regex_pattern_set_reference_statement": [],
+										"rule_group_reference_statement":        [],
+										"size_constraint_statement":             [],
+										"sqli_match_statement":                  [],
+										"xss_match_statement":                   [],
+									},
+								],
+								"visibility_config": [
+									{},
+								],
+							},
+						],
+						"tags":     {},
+						"tags_all": {},
+						"token_domains": [
+							false,
+							false,
+						],
+						"visibility_config": [
+							{},
+						],
+					},
+					"type": "aws_wafv2_web_acl",
+					"values": {
+						"association_config":   [],
+						"captcha_config":       [],
+						"challenge_config":     [],
+						"custom_response_body": [],
+						"default_action": [
+							{
+								"allow": [
+									{
+										"custom_request_handling": [],
+									},
+								],
+								"block": [],
+							},
+						],
+						"description": "Example of a managed rule.",
+						"name":        "managed-rule-example",
+						"rule": [
+							{
+								"action":           [],
+								"captcha_config":   [],
+								"challenge_config": [],
+								"name":             "rule-1",
+								"override_action": [
+									{
+										"count": [
+											{},
+										],
+										"none": [],
+									},
+								],
+								"priority":   1,
+								"rule_label": [],
+								"statement": [
+									{
+										"and_statement":              [],
+										"byte_match_statement":       [],
+										"geo_match_statement":        [],
+										"ip_set_reference_statement": [],
+										"label_match_statement":      [],
+										"managed_rule_group_statement": [
+											{
+												"managed_rule_group_configs": [],
+												"name": "AWSManagedRulesCommonRuleSet",
+												"rule_action_override": [
+													{
+														"action_to_use": [
+															{
+																"allow":     [],
+																"block":     [],
+																"captcha":   [],
+																"challenge": [],
+																"count": [
+																	{
+																		"custom_request_handling": [],
+																	},
+																],
+															},
+														],
+														"name": "SizeRestrictions_QUERYSTRING",
+													},
+													{
+														"action_to_use": [
+															{
+																"allow":     [],
+																"block":     [],
+																"captcha":   [],
+																"challenge": [],
+																"count": [
+																	{
+																		"custom_request_handling": [],
+																	},
+																],
+															},
+														],
+														"name": "NoUserAgent_HEADER",
+													},
+												],
+												"scope_down_statement": [
+													{
+														"and_statement":        [],
+														"byte_match_statement": [],
+														"geo_match_statement": [
+															{
+																"country_codes": [
+																	"US",
+																	"NL",
+																],
+																"forwarded_ip_config": [],
+															},
+														],
+														"ip_set_reference_statement":            [],
+														"label_match_statement":                 [],
+														"not_statement":                         [],
+														"or_statement":                          [],
+														"regex_match_statement":                 [],
+														"regex_pattern_set_reference_statement": [],
+														"size_constraint_statement":             [],
+														"sqli_match_statement":                  [],
+														"xss_match_statement":                   [],
+													},
+												],
+												"vendor_name": "AWS",
+												"version":     "",
+											},
+										],
+										"not_statement":                         [],
+										"or_statement":                          [],
+										"rate_based_statement":                  [],
+										"regex_match_statement":                 [],
+										"regex_pattern_set_reference_statement": [],
+										"rule_group_reference_statement":        [],
+										"size_constraint_statement":             [],
+										"sqli_match_statement":                  [],
+										"xss_match_statement":                   [],
+									},
+								],
+								"visibility_config": [
+									{
+										"cloudwatch_metrics_enabled": false,
+										"metric_name":                "friendly-rule-metric-name",
+										"sampled_requests_enabled":   false,
+									},
+								],
+							},
+						],
+						"rule_json": null,
+						"scope":     "REGIONAL",
+						"tags": {
+							"Tag1": "Value1",
+							"Tag2": "Value2",
+						},
+						"tags_all": {
+							"Tag1": "Value1",
+							"Tag2": "Value2",
+						},
+						"token_domains": [
+							"myotherwebsite.com",
+							"mywebsite.com",
+						],
+						"visibility_config": [
+							{
+								"cloudwatch_metrics_enabled": false,
+								"metric_name":                "friendly-metric-name",
+								"sampled_requests_enabled":   false,
+							},
+						],
+					},
+				},
+			],
+		},
+	},
+	"resource_changes": [
+		{
+			"address": "aws_wafv2_web_acl.example",
+			"change": {
+				"actions": [
+					"create",
+				],
+				"after": {
+					"association_config":   [],
+					"captcha_config":       [],
+					"challenge_config":     [],
+					"custom_response_body": [],
+					"default_action": [
+						{
+							"allow": [
+								{
+									"custom_request_handling": [],
+								},
+							],
+							"block": [],
+						},
+					],
+					"description": "Example of a managed rule.",
+					"name":        "managed-rule-example",
+					"rule": [
+						{
+							"action":           [],
+							"captcha_config":   [],
+							"challenge_config": [],
+							"name":             "rule-1",
+							"override_action": [
+								{
+									"count": [
+										{},
+									],
+									"none": [],
+								},
+							],
+							"priority":   1,
+							"rule_label": [],
+							"statement": [
+								{
+									"and_statement":              [],
+									"byte_match_statement":       [],
+									"geo_match_statement":        [],
+									"ip_set_reference_statement": [],
+									"label_match_statement":      [],
+									"managed_rule_group_statement": [
+										{
+											"managed_rule_group_configs": [],
+											"name": "AWSManagedRulesCommonRuleSet",
+											"rule_action_override": [
+												{
+													"action_to_use": [
+														{
+															"allow":     [],
+															"block":     [],
+															"captcha":   [],
+															"challenge": [],
+															"count": [
+																{
+																	"custom_request_handling": [],
+																},
+															],
+														},
+													],
+													"name": "SizeRestrictions_QUERYSTRING",
+												},
+												{
+													"action_to_use": [
+														{
+															"allow":     [],
+															"block":     [],
+															"captcha":   [],
+															"challenge": [],
+															"count": [
+																{
+																	"custom_request_handling": [],
+																},
+															],
+														},
+													],
+													"name": "NoUserAgent_HEADER",
+												},
+											],
+											"scope_down_statement": [
+												{
+													"and_statement":        [],
+													"byte_match_statement": [],
+													"geo_match_statement": [
+														{
+															"country_codes": [
+																"US",
+																"NL",
+															],
+															"forwarded_ip_config": [],
+														},
+													],
+													"ip_set_reference_statement":            [],
+													"label_match_statement":                 [],
+													"not_statement":                         [],
+													"or_statement":                          [],
+													"regex_match_statement":                 [],
+													"regex_pattern_set_reference_statement": [],
+													"size_constraint_statement":             [],
+													"sqli_match_statement":                  [],
+													"xss_match_statement":                   [],
+												},
+											],
+											"vendor_name": "AWS",
+											"version":     "",
+										},
+									],
+									"not_statement":                         [],
+									"or_statement":                          [],
+									"rate_based_statement":                  [],
+									"regex_match_statement":                 [],
+									"regex_pattern_set_reference_statement": [],
+									"rule_group_reference_statement":        [],
+									"size_constraint_statement":             [],
+									"sqli_match_statement":                  [],
+									"xss_match_statement":                   [],
+								},
+							],
+							"visibility_config": [
+								{
+									"cloudwatch_metrics_enabled": false,
+									"metric_name":                "friendly-rule-metric-name",
+									"sampled_requests_enabled":   false,
+								},
+							],
+						},
+					],
+					"rule_json": null,
+					"scope":     "REGIONAL",
+					"tags": {
+						"Tag1": "Value1",
+						"Tag2": "Value2",
+					},
+					"tags_all": {
+						"Tag1": "Value1",
+						"Tag2": "Value2",
+					},
+					"token_domains": [
+						"myotherwebsite.com",
+						"mywebsite.com",
+					],
+					"visibility_config": [
+						{
+							"cloudwatch_metrics_enabled": false,
+							"metric_name":                "friendly-metric-name",
+							"sampled_requests_enabled":   false,
+						},
+					],
+				},
+				"after_sensitive": {
+					"association_config":   [],
+					"captcha_config":       [],
+					"challenge_config":     [],
+					"custom_response_body": [],
+					"default_action": [
+						{
+							"allow": [
+								{
+									"custom_request_handling": [],
+								},
+							],
+							"block": [],
+						},
+					],
+					"rule": [
+						{
+							"action":           [],
+							"captcha_config":   [],
+							"challenge_config": [],
+							"override_action": [
+								{
+									"count": [
+										{},
+									],
+									"none": [],
+								},
+							],
+							"rule_label": [],
+							"statement": [
+								{
+									"and_statement":              [],
+									"byte_match_statement":       [],
+									"geo_match_statement":        [],
+									"ip_set_reference_statement": [],
+									"label_match_statement":      [],
+									"managed_rule_group_statement": [
+										{
+											"managed_rule_group_configs": [],
+											"rule_action_override": [
+												{
+													"action_to_use": [
+														{
+															"allow":     [],
+															"block":     [],
+															"captcha":   [],
+															"challenge": [],
+															"count": [
+																{
+																	"custom_request_handling": [],
+																},
+															],
+														},
+													],
+												},
+												{
+													"action_to_use": [
+														{
+															"allow":     [],
+															"block":     [],
+															"captcha":   [],
+															"challenge": [],
+															"count": [
+																{
+																	"custom_request_handling": [],
+																},
+															],
+														},
+													],
+												},
+											],
+											"scope_down_statement": [
+												{
+													"and_statement":        [],
+													"byte_match_statement": [],
+													"geo_match_statement": [
+														{
+															"country_codes": [
+																false,
+																false,
+															],
+															"forwarded_ip_config": [],
+														},
+													],
+													"ip_set_reference_statement":            [],
+													"label_match_statement":                 [],
+													"not_statement":                         [],
+													"or_statement":                          [],
+													"regex_match_statement":                 [],
+													"regex_pattern_set_reference_statement": [],
+													"size_constraint_statement":             [],
+													"sqli_match_statement":                  [],
+													"xss_match_statement":                   [],
+												},
+											],
+										},
+									],
+									"not_statement":                         [],
+									"or_statement":                          [],
+									"rate_based_statement":                  [],
+									"regex_match_statement":                 [],
+									"regex_pattern_set_reference_statement": [],
+									"rule_group_reference_statement":        [],
+									"size_constraint_statement":             [],
+									"sqli_match_statement":                  [],
+									"xss_match_statement":                   [],
+								},
+							],
+							"visibility_config": [
+								{},
+							],
+						},
+					],
+					"tags":     {},
+					"tags_all": {},
+					"token_domains": [
+						false,
+						false,
+					],
+					"visibility_config": [
+						{},
+					],
+				},
+				"after_unknown": {
+					"application_integration_url": true,
+					"arn":                  true,
+					"association_config":   [],
+					"capacity":             true,
+					"captcha_config":       [],
+					"challenge_config":     [],
+					"custom_response_body": [],
+					"default_action": [
+						{
+							"allow": [
+								{
+									"custom_request_handling": [],
+								},
+							],
+							"block": [],
+						},
+					],
+					"id":          true,
+					"lock_token":  true,
+					"name_prefix": true,
+					"rule": [
+						{
+							"action":           [],
+							"captcha_config":   [],
+							"challenge_config": [],
+							"override_action": [
+								{
+									"count": [
+										{},
+									],
+									"none": [],
+								},
+							],
+							"rule_label": [],
+							"statement": [
+								{
+									"and_statement":              [],
+									"byte_match_statement":       [],
+									"geo_match_statement":        [],
+									"ip_set_reference_statement": [],
+									"label_match_statement":      [],
+									"managed_rule_group_statement": [
+										{
+											"managed_rule_group_configs": [],
+											"rule_action_override": [
+												{
+													"action_to_use": [
+														{
+															"allow":     [],
+															"block":     [],
+															"captcha":   [],
+															"challenge": [],
+															"count": [
+																{
+																	"custom_request_handling": [],
+																},
+															],
+														},
+													],
+												},
+												{
+													"action_to_use": [
+														{
+															"allow":     [],
+															"block":     [],
+															"captcha":   [],
+															"challenge": [],
+															"count": [
+																{
+																	"custom_request_handling": [],
+																},
+															],
+														},
+													],
+												},
+											],
+											"scope_down_statement": [
+												{
+													"and_statement":        [],
+													"byte_match_statement": [],
+													"geo_match_statement": [
+														{
+															"country_codes": [
+																false,
+																false,
+															],
+															"forwarded_ip_config": [],
+														},
+													],
+													"ip_set_reference_statement":            [],
+													"label_match_statement":                 [],
+													"not_statement":                         [],
+													"or_statement":                          [],
+													"regex_match_statement":                 [],
+													"regex_pattern_set_reference_statement": [],
+													"size_constraint_statement":             [],
+													"sqli_match_statement":                  [],
+													"xss_match_statement":                   [],
+												},
+											],
+										},
+									],
+									"not_statement":                         [],
+									"or_statement":                          [],
+									"rate_based_statement":                  [],
+									"regex_match_statement":                 [],
+									"regex_pattern_set_reference_statement": [],
+									"rule_group_reference_statement":        [],
+									"size_constraint_statement":             [],
+									"sqli_match_statement":                  [],
+									"xss_match_statement":                   [],
+								},
+							],
+							"visibility_config": [
+								{},
+							],
+						},
+					],
+					"tags":     {},
+					"tags_all": {},
+					"token_domains": [
+						false,
+						false,
+					],
+					"visibility_config": [
+						{},
+					],
+				},
+				"before":           null,
+				"before_sensitive": false,
+			},
+			"mode":          "managed",
+			"name":          "example",
+			"provider_name": "registry.terraform.io/hashicorp/aws",
+			"type":          "aws_wafv2_web_acl",
+		},
+	],
+	"terraform_version": "1.10.2",
+	"timestamp":         "2025-04-08T05:36:36Z",
+}

--- a/policies/test/wafv2-webacl-not-empty/success-multiple-rules-are-present.hcl
+++ b/policies/test/wafv2-webacl-not-empty/success-multiple-rules-are-present.hcl
@@ -1,0 +1,23 @@
+mock "tfplan/v2" {
+	module {
+		source = "./mocks/policy-success-multiple-rules-are-present/mock-tfplan-v2.sentinel"
+	}
+}
+
+
+
+import "plugin" "tfresources" {
+	source = "../../../plugins/darwin/arm64/sentinel-plugin-tfresources"
+}
+
+mock "report" {
+	module {
+		source = "../../../modules/mocks/report/report.sentinel"
+	}
+}
+
+test {
+	rules = {
+		main = true
+	}
+}

--- a/policies/test/wafv2-webacl-not-empty/success-rules-are-present.hcl
+++ b/policies/test/wafv2-webacl-not-empty/success-rules-are-present.hcl
@@ -1,0 +1,23 @@
+mock "tfplan/v2" {
+	module {
+		source = "./mocks/policy-success-rules-are-present/mock-tfplan-v2.sentinel"
+	}
+}
+
+
+
+import "plugin" "tfresources" {
+	source = "../../../plugins/darwin/arm64/sentinel-plugin-tfresources"
+}
+
+mock "report" {
+	module {
+		source = "../../../modules/mocks/report/report.sentinel"
+	}
+}
+
+test {
+	rules = {
+		main = true
+	}
+}

--- a/policies/wafv2-webacl-not-empty.sentinel
+++ b/policies/wafv2-webacl-not-empty.sentinel
@@ -1,0 +1,53 @@
+# This policy requires resources of type `aws_wafv2_web_acl` to have at least one rule or rule group.
+
+# Imports
+
+import "tfplan/v2" as tfplan
+import "tfresources" as tf
+import "report" as report
+import "collection" as collection
+import "collection/maps" as maps
+
+# Constants
+
+const = {
+	"policy_name":                "wafv2-webacl-not-empty",
+	"message":                    "AWS WAF web ACLs should have at least one rule or rule group. Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/waf-controls.html#waf-10 for more details.",
+	"resource_aws_wafv2_web_acl": "aws_wafv2_web_acl",
+	"rule": "rule",
+}
+
+# Functions
+
+has_rule_or_rule_group = func(res) {
+	rules = maps.get(res.values, const.rule, [])
+	return length(rules) > 0
+}
+
+# Variables
+
+resources = tf.plan(tfplan.planned_values.resources).type(const.resource_aws_wafv2_web_acl).resources
+violations = collection.reject(resources, func(res) {
+	return has_rule_or_rule_group(res)
+})
+
+summary = {
+	"policy_name": const.policy_name,
+	"violations": map violations as _, v {
+		{
+			"address":        v.address,
+			"module_address": v.module_address,
+			"message":        const.message,
+		}
+	},
+}
+
+# Outputs
+
+print(report.generate_policy_report(summary))
+
+# Rules
+
+main = rule {
+	violations is empty
+}

--- a/sentinel.hcl
+++ b/sentinel.hcl
@@ -973,3 +973,8 @@ policy "kinesis-firehose-delivery-stream-encrypted" {
   source = "./policies/kinesis-firehose-delivery-stream-encrypted.sentinel"
   enforcement_level = "advisory"
 }
+
+policy "wafv2-webacl-not-empty" {
+  source = "./policies/wafv2-webacl-not-empty.sentinel"
+  enforcement_level = "advisory"
+}

--- a/tests/acceptance/wafv2-webacl-not-empty/cases/rules-are-not-present/backend.tf
+++ b/tests/acceptance/wafv2-webacl-not-empty/cases/rules-are-not-present/backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  cloud {
+    workspaces {
+      name = "wafv2-webacl-not-empty"
+    }
+  }
+}

--- a/tests/acceptance/wafv2-webacl-not-empty/cases/rules-are-not-present/main.tf
+++ b/tests/acceptance/wafv2-webacl-not-empty/cases/rules-are-not-present/main.tf
@@ -1,0 +1,26 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+resource "aws_wafv2_web_acl" "example" {
+  name        = "managed-rule-example"
+  description = "Example of a managed rule."
+  scope       = "REGIONAL"
+
+  default_action {
+    allow {}
+  }
+
+  tags = {
+    Tag1 = "Value1"
+    Tag2 = "Value2"
+  }
+
+  token_domains = ["mywebsite.com", "myotherwebsite.com"]
+
+  visibility_config {
+    cloudwatch_metrics_enabled = false
+    metric_name                = "friendly-metric-name"
+    sampled_requests_enabled   = false
+  }
+}

--- a/tests/acceptance/wafv2-webacl-not-empty/cases/rules-are-present/backend.tf
+++ b/tests/acceptance/wafv2-webacl-not-empty/cases/rules-are-present/backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  cloud {
+    workspaces {
+      name = "wafv2-webacl-not-empty"
+    }
+  }
+}

--- a/tests/acceptance/wafv2-webacl-not-empty/cases/rules-are-present/main.tf
+++ b/tests/acceptance/wafv2-webacl-not-empty/cases/rules-are-present/main.tf
@@ -1,0 +1,112 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+resource "aws_wafv2_web_acl" "example" {
+  name        = "managed-rule-example"
+  description = "Example of a managed rule."
+  scope       = "REGIONAL"
+
+  default_action {
+    allow {}
+  }
+
+  rule {
+    name     = "rule-1"
+    priority = 1
+
+    override_action {
+      count {}
+    }
+
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesCommonRuleSet"
+        vendor_name = "AWS"
+
+        rule_action_override {
+          action_to_use {
+            count {}
+          }
+
+          name = "SizeRestrictions_QUERYSTRING"
+        }
+
+        rule_action_override {
+          action_to_use {
+            count {}
+          }
+
+          name = "NoUserAgent_HEADER"
+        }
+
+        scope_down_statement {
+          geo_match_statement {
+            country_codes = ["US", "NL"]
+          }
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = false
+      metric_name                = "friendly-rule-metric-name"
+      sampled_requests_enabled   = false
+    }
+  }
+
+  rule {
+    name     = "rule-to-exclude-a"
+    priority = 10
+
+    action {
+      allow {}
+    }
+
+    statement {
+      geo_match_statement {
+        country_codes = ["US"]
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = false
+      metric_name                = "friendly-rule-metric-name"
+      sampled_requests_enabled   = false
+    }
+  }
+
+  rule {
+    name     = "rule-to-exclude-b"
+    priority = 15
+
+    action {
+      allow {}
+    }
+
+    statement {
+      geo_match_statement {
+        country_codes = ["GB"]
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = false
+      metric_name                = "friendly-rule-metric-name"
+      sampled_requests_enabled   = false
+    }
+  }
+
+  tags = {
+    Tag1 = "Value1"
+    Tag2 = "Value2"
+  }
+
+  token_domains = ["mywebsite.com", "myotherwebsite.com"]
+
+  visibility_config {
+    cloudwatch_metrics_enabled = false
+    metric_name                = "friendly-metric-name"
+    sampled_requests_enabled   = false
+  }
+}

--- a/tests/acceptance/wafv2-webacl-not-empty/test-config.hcl
+++ b/tests/acceptance/wafv2-webacl-not-empty/test-config.hcl
@@ -1,0 +1,17 @@
+name = "wafv2-webacl-not-empty"
+
+disabled = false
+
+case "WAFv2 Web ACL with Rules Present" {
+    path = "./cases/rules-are-present"
+    expectation {
+        result = true
+    }
+}
+
+case "WAFv2 Web ACL with Rules Not Present" {
+    path = "./cases/rules-are-not-present"
+    expectation {
+        result = false
+    }
+}


### PR DESCRIPTION
## Changes proposed in this PR:
- Added wafv2-webacl-not-empty

## Documentation
- [AWS Standard](https://docs.aws.amazon.com/securityhub/latest/userguide/waf-controls.html#waf-10)
- [Policy details](https://docs.aws.amazon.com/securityhub/latest/userguide/waf-controls.html#waf-10)

## AWS Provider version
<!-- Add information about the provider version against which the policy was tested/developed with. This will later help us when we deal with documentation.Add any nuances that you've observed around provider versions. For example, some attributes will only be present in a certain version of a provider and we need to clearly document that so that users use the expected version.-->

## How I've tested this PR:

## Checklist:
- [x] Tests added