### PR TITLE
Added wafv2-rulegroup-logging-enabled

### DIFF
--- a/docs/policies/wafv2-rulegroup-logging-enabled.md
+++ b/docs/policies/wafv2-rulegroup-logging-enabled.md
@@ -1,0 +1,67 @@
+# AWS WAF rules should have CloudWatch metrics enabled
+
+| Provider            | Category     |
+|---------------------|--------------|
+| Amazon Web Services | Logging      |
+
+## Description
+
+This control checks whether an AWS WAF rule or rule group has Amazon CloudWatch metrics enabled. The control fails if the rule or rule group doesn't have CloudWatch metrics enabled.
+
+Configuring CloudWatch metrics on AWS WAF rules and rule groups provides visibility into traffic flow. You can see which ACL rules are triggered and which requests are accepted and blocked. This visibility can help you identify malicious activity on your associated resources.
+
+This rule is covered by the [wafv2-rulegroup-logging-enabled](../../policies/wafv2-rulegroup-logging-enabled.sentinel) policy.
+
+## Policy Results (Pass)
+```bash
+trace:
+      Pass - wafv2-rulegroup-logging-enabled.sentinel
+
+      Description:
+        This policy requires resources of type `aws_wafv2_rule_group` have attribute
+        'cloudwatch_metrics_enabled' set to true.
+
+      Print messages:
+
+      → → Overall Result: true
+
+      This result means that all resources have passed the policy check for the policy wafv2-rulegroup-logging-enabled.
+
+      ✓ Found 0 resource violations
+
+      wafv2-rulegroup-logging-enabled.sentinel:49:1 - Rule "main"
+        Value:
+          true
+```
+
+---
+
+## Policy Results (Fail)
+```bash
+trace:
+      Fail - wafv2-rulegroup-logging-enabled.sentinel
+
+      Description:
+        This policy requires resources of type `aws_wafv2_rule_group` have attribute
+        'cloudwatch_metrics_enabled' set to true.
+
+      Print messages:
+
+      → → Overall Result: false
+
+      This result means that not all resources passed the policy check and the protected behavior is not allowed for the policy wafv2-rulegroup-logging-enabled.
+
+      Found 1 resource violations
+
+      → Module name: root
+        ↳ Resource Address: aws_wafv2_rule_group.example
+          | ✗ failed
+          | Attribute 'visibility_config.cloudwatch_metrics_enabled' must be set to true for 'aws_wafv2_rule_group' resources. Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/waf-controls.html#waf-12 for more details.
+
+
+      wafv2-rulegroup-logging-enabled.sentinel:49:1 - Rule "main"
+        Value:
+          false
+```
+
+---

--- a/policies/test/wafv2-rulegroup-logging-enabled/failure-cloudwatch-metrics-disabled.hcl
+++ b/policies/test/wafv2-rulegroup-logging-enabled/failure-cloudwatch-metrics-disabled.hcl
@@ -1,0 +1,23 @@
+mock "tfplan/v2" {
+	module {
+		source = "./mocks/policy-failure-cloudwatch-metrics-disabled/mock-tfplan-v2.sentinel"
+	}
+}
+
+
+
+import "plugin" "tfresources" {
+	source = "../../../plugins/darwin/arm64/sentinel-plugin-tfresources"
+}
+
+mock "report" {
+	module {
+		source = "../../../modules/mocks/report/report.sentinel"
+	}
+}
+
+test {
+	rules = {
+		main = false
+	}
+}

--- a/policies/test/wafv2-rulegroup-logging-enabled/mocks/policy-failure-cloudwatch-metrics-disabled/mock-tfplan-v2.sentinel
+++ b/policies/test/wafv2-rulegroup-logging-enabled/mocks/policy-failure-cloudwatch-metrics-disabled/mock-tfplan-v2.sentinel
@@ -1,0 +1,670 @@
+terraform_version = "1.10.2"
+
+planned_values = {
+	"outputs": {},
+	"resources": {
+		"aws_wafv2_rule_group.example": {
+			"address":        "aws_wafv2_rule_group.example",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "example",
+			"provider_name":  "registry.terraform.io/hashicorp/aws",
+			"tainted":        false,
+			"type":           "aws_wafv2_rule_group",
+			"values": {
+				"capacity":             2,
+				"custom_response_body": [],
+				"description":          null,
+				"name":                 "example-rule",
+				"rule": [
+					{
+						"action": [
+							{
+								"allow": [
+									{
+										"custom_request_handling": [],
+									},
+								],
+								"block":     [],
+								"captcha":   [],
+								"challenge": [],
+								"count":     [],
+							},
+						],
+						"captcha_config": [],
+						"name":           "rule-1",
+						"priority":       1,
+						"rule_label":     [],
+						"statement": [
+							{
+								"and_statement":        [],
+								"byte_match_statement": [],
+								"geo_match_statement": [
+									{
+										"country_codes": [
+											"US",
+											"NL",
+										],
+										"forwarded_ip_config": [],
+									},
+								],
+								"ip_set_reference_statement":            [],
+								"label_match_statement":                 [],
+								"not_statement":                         [],
+								"or_statement":                          [],
+								"rate_based_statement":                  [],
+								"regex_match_statement":                 [],
+								"regex_pattern_set_reference_statement": [],
+								"size_constraint_statement":             [],
+								"sqli_match_statement":                  [],
+								"xss_match_statement":                   [],
+							},
+						],
+						"visibility_config": [
+							{
+								"cloudwatch_metrics_enabled": false,
+								"metric_name":                "friendly-rule-metric-name",
+								"sampled_requests_enabled":   false,
+							},
+						],
+					},
+				],
+				"scope": "REGIONAL",
+				"tags":  null,
+				"visibility_config": [
+					{
+						"cloudwatch_metrics_enabled": false,
+						"metric_name":                "friendly-metric-name",
+						"sampled_requests_enabled":   false,
+					},
+				],
+			},
+		},
+	},
+}
+
+variables = {}
+
+resource_changes = {
+	"aws_wafv2_rule_group.example": {
+		"address": "aws_wafv2_rule_group.example",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"capacity":             2,
+				"custom_response_body": [],
+				"description":          null,
+				"name":                 "example-rule",
+				"rule": [
+					{
+						"action": [
+							{
+								"allow": [
+									{
+										"custom_request_handling": [],
+									},
+								],
+								"block":     [],
+								"captcha":   [],
+								"challenge": [],
+								"count":     [],
+							},
+						],
+						"captcha_config": [],
+						"name":           "rule-1",
+						"priority":       1,
+						"rule_label":     [],
+						"statement": [
+							{
+								"and_statement":        [],
+								"byte_match_statement": [],
+								"geo_match_statement": [
+									{
+										"country_codes": [
+											"US",
+											"NL",
+										],
+										"forwarded_ip_config": [],
+									},
+								],
+								"ip_set_reference_statement":            [],
+								"label_match_statement":                 [],
+								"not_statement":                         [],
+								"or_statement":                          [],
+								"rate_based_statement":                  [],
+								"regex_match_statement":                 [],
+								"regex_pattern_set_reference_statement": [],
+								"size_constraint_statement":             [],
+								"sqli_match_statement":                  [],
+								"xss_match_statement":                   [],
+							},
+						],
+						"visibility_config": [
+							{
+								"cloudwatch_metrics_enabled": false,
+								"metric_name":                "friendly-rule-metric-name",
+								"sampled_requests_enabled":   false,
+							},
+						],
+					},
+				],
+				"scope": "REGIONAL",
+				"tags":  null,
+				"visibility_config": [
+					{
+						"cloudwatch_metrics_enabled": false,
+						"metric_name":                "friendly-metric-name",
+						"sampled_requests_enabled":   false,
+					},
+				],
+			},
+			"after_unknown": {
+				"arn": true,
+				"custom_response_body": [],
+				"id":          true,
+				"lock_token":  true,
+				"name_prefix": true,
+				"rule": [
+					{
+						"action": [
+							{
+								"allow": [
+									{
+										"custom_request_handling": [],
+									},
+								],
+								"block":     [],
+								"captcha":   [],
+								"challenge": [],
+								"count":     [],
+							},
+						],
+						"captcha_config": [],
+						"rule_label":     [],
+						"statement": [
+							{
+								"and_statement":        [],
+								"byte_match_statement": [],
+								"geo_match_statement": [
+									{
+										"country_codes": [
+											false,
+											false,
+										],
+										"forwarded_ip_config": [],
+									},
+								],
+								"ip_set_reference_statement":            [],
+								"label_match_statement":                 [],
+								"not_statement":                         [],
+								"or_statement":                          [],
+								"rate_based_statement":                  [],
+								"regex_match_statement":                 [],
+								"regex_pattern_set_reference_statement": [],
+								"size_constraint_statement":             [],
+								"sqli_match_statement":                  [],
+								"xss_match_statement":                   [],
+							},
+						],
+						"visibility_config": [
+							{},
+						],
+					},
+				],
+				"tags_all": true,
+				"visibility_config": [
+					{},
+				],
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "example",
+		"provider_name":  "registry.terraform.io/hashicorp/aws",
+		"type":           "aws_wafv2_rule_group",
+	},
+}
+
+resource_drift = {}
+
+output_changes = {}
+
+raw = {
+	"complete": true,
+	"configuration": {
+		"provider_config": {
+			"aws": {
+				"expressions": {
+					"region": {
+						"constant_value": "us-east-1",
+					},
+				},
+				"full_name": "registry.terraform.io/hashicorp/aws",
+				"name":      "aws",
+			},
+		},
+		"root_module": {
+			"resources": [
+				{
+					"address": "aws_wafv2_rule_group.example",
+					"expressions": {
+						"capacity": {
+							"constant_value": 2,
+						},
+						"name": {
+							"constant_value": "example-rule",
+						},
+						"rule": [
+							{
+								"action": [
+									{
+										"allow": [
+											{},
+										],
+									},
+								],
+								"name": {
+									"constant_value": "rule-1",
+								},
+								"priority": {
+									"constant_value": 1,
+								},
+								"statement": [
+									{
+										"geo_match_statement": [
+											{
+												"country_codes": {
+													"constant_value": [
+														"US",
+														"NL",
+													],
+												},
+											},
+										],
+									},
+								],
+								"visibility_config": [
+									{
+										"cloudwatch_metrics_enabled": {
+											"constant_value": false,
+										},
+										"metric_name": {
+											"constant_value": "friendly-rule-metric-name",
+										},
+										"sampled_requests_enabled": {
+											"constant_value": false,
+										},
+									},
+								],
+							},
+						],
+						"scope": {
+							"constant_value": "REGIONAL",
+						},
+						"visibility_config": [
+							{
+								"cloudwatch_metrics_enabled": {
+									"constant_value": false,
+								},
+								"metric_name": {
+									"constant_value": "friendly-metric-name",
+								},
+								"sampled_requests_enabled": {
+									"constant_value": false,
+								},
+							},
+						],
+					},
+					"mode":                "managed",
+					"name":                "example",
+					"provider_config_key": "aws",
+					"schema_version":      0,
+					"type":                "aws_wafv2_rule_group",
+				},
+			],
+		},
+	},
+	"format_version": "1.2",
+	"planned_values": {
+		"root_module": {
+			"resources": [
+				{
+					"address":        "aws_wafv2_rule_group.example",
+					"mode":           "managed",
+					"name":           "example",
+					"provider_name":  "registry.terraform.io/hashicorp/aws",
+					"schema_version": 0,
+					"sensitive_values": {
+						"custom_response_body": [],
+						"rule": [
+							{
+								"action": [
+									{
+										"allow": [
+											{
+												"custom_request_handling": [],
+											},
+										],
+										"block":     [],
+										"captcha":   [],
+										"challenge": [],
+										"count":     [],
+									},
+								],
+								"captcha_config": [],
+								"rule_label":     [],
+								"statement": [
+									{
+										"and_statement":        [],
+										"byte_match_statement": [],
+										"geo_match_statement": [
+											{
+												"country_codes": [
+													false,
+													false,
+												],
+												"forwarded_ip_config": [],
+											},
+										],
+										"ip_set_reference_statement":            [],
+										"label_match_statement":                 [],
+										"not_statement":                         [],
+										"or_statement":                          [],
+										"rate_based_statement":                  [],
+										"regex_match_statement":                 [],
+										"regex_pattern_set_reference_statement": [],
+										"size_constraint_statement":             [],
+										"sqli_match_statement":                  [],
+										"xss_match_statement":                   [],
+									},
+								],
+								"visibility_config": [
+									{},
+								],
+							},
+						],
+						"tags_all": {},
+						"visibility_config": [
+							{},
+						],
+					},
+					"type": "aws_wafv2_rule_group",
+					"values": {
+						"capacity":             2,
+						"custom_response_body": [],
+						"description":          null,
+						"name":                 "example-rule",
+						"rule": [
+							{
+								"action": [
+									{
+										"allow": [
+											{
+												"custom_request_handling": [],
+											},
+										],
+										"block":     [],
+										"captcha":   [],
+										"challenge": [],
+										"count":     [],
+									},
+								],
+								"captcha_config": [],
+								"name":           "rule-1",
+								"priority":       1,
+								"rule_label":     [],
+								"statement": [
+									{
+										"and_statement":        [],
+										"byte_match_statement": [],
+										"geo_match_statement": [
+											{
+												"country_codes": [
+													"US",
+													"NL",
+												],
+												"forwarded_ip_config": [],
+											},
+										],
+										"ip_set_reference_statement":            [],
+										"label_match_statement":                 [],
+										"not_statement":                         [],
+										"or_statement":                          [],
+										"rate_based_statement":                  [],
+										"regex_match_statement":                 [],
+										"regex_pattern_set_reference_statement": [],
+										"size_constraint_statement":             [],
+										"sqli_match_statement":                  [],
+										"xss_match_statement":                   [],
+									},
+								],
+								"visibility_config": [
+									{
+										"cloudwatch_metrics_enabled": false,
+										"metric_name":                "friendly-rule-metric-name",
+										"sampled_requests_enabled":   false,
+									},
+								],
+							},
+						],
+						"scope": "REGIONAL",
+						"tags":  null,
+						"visibility_config": [
+							{
+								"cloudwatch_metrics_enabled": false,
+								"metric_name":                "friendly-metric-name",
+								"sampled_requests_enabled":   false,
+							},
+						],
+					},
+				},
+			],
+		},
+	},
+	"resource_changes": [
+		{
+			"address": "aws_wafv2_rule_group.example",
+			"change": {
+				"actions": [
+					"create",
+				],
+				"after": {
+					"capacity":             2,
+					"custom_response_body": [],
+					"description":          null,
+					"name":                 "example-rule",
+					"rule": [
+						{
+							"action": [
+								{
+									"allow": [
+										{
+											"custom_request_handling": [],
+										},
+									],
+									"block":     [],
+									"captcha":   [],
+									"challenge": [],
+									"count":     [],
+								},
+							],
+							"captcha_config": [],
+							"name":           "rule-1",
+							"priority":       1,
+							"rule_label":     [],
+							"statement": [
+								{
+									"and_statement":        [],
+									"byte_match_statement": [],
+									"geo_match_statement": [
+										{
+											"country_codes": [
+												"US",
+												"NL",
+											],
+											"forwarded_ip_config": [],
+										},
+									],
+									"ip_set_reference_statement":            [],
+									"label_match_statement":                 [],
+									"not_statement":                         [],
+									"or_statement":                          [],
+									"rate_based_statement":                  [],
+									"regex_match_statement":                 [],
+									"regex_pattern_set_reference_statement": [],
+									"size_constraint_statement":             [],
+									"sqli_match_statement":                  [],
+									"xss_match_statement":                   [],
+								},
+							],
+							"visibility_config": [
+								{
+									"cloudwatch_metrics_enabled": false,
+									"metric_name":                "friendly-rule-metric-name",
+									"sampled_requests_enabled":   false,
+								},
+							],
+						},
+					],
+					"scope": "REGIONAL",
+					"tags":  null,
+					"visibility_config": [
+						{
+							"cloudwatch_metrics_enabled": false,
+							"metric_name":                "friendly-metric-name",
+							"sampled_requests_enabled":   false,
+						},
+					],
+				},
+				"after_sensitive": {
+					"custom_response_body": [],
+					"rule": [
+						{
+							"action": [
+								{
+									"allow": [
+										{
+											"custom_request_handling": [],
+										},
+									],
+									"block":     [],
+									"captcha":   [],
+									"challenge": [],
+									"count":     [],
+								},
+							],
+							"captcha_config": [],
+							"rule_label":     [],
+							"statement": [
+								{
+									"and_statement":        [],
+									"byte_match_statement": [],
+									"geo_match_statement": [
+										{
+											"country_codes": [
+												false,
+												false,
+											],
+											"forwarded_ip_config": [],
+										},
+									],
+									"ip_set_reference_statement":            [],
+									"label_match_statement":                 [],
+									"not_statement":                         [],
+									"or_statement":                          [],
+									"rate_based_statement":                  [],
+									"regex_match_statement":                 [],
+									"regex_pattern_set_reference_statement": [],
+									"size_constraint_statement":             [],
+									"sqli_match_statement":                  [],
+									"xss_match_statement":                   [],
+								},
+							],
+							"visibility_config": [
+								{},
+							],
+						},
+					],
+					"tags_all": {},
+					"visibility_config": [
+						{},
+					],
+				},
+				"after_unknown": {
+					"arn": true,
+					"custom_response_body": [],
+					"id":          true,
+					"lock_token":  true,
+					"name_prefix": true,
+					"rule": [
+						{
+							"action": [
+								{
+									"allow": [
+										{
+											"custom_request_handling": [],
+										},
+									],
+									"block":     [],
+									"captcha":   [],
+									"challenge": [],
+									"count":     [],
+								},
+							],
+							"captcha_config": [],
+							"rule_label":     [],
+							"statement": [
+								{
+									"and_statement":        [],
+									"byte_match_statement": [],
+									"geo_match_statement": [
+										{
+											"country_codes": [
+												false,
+												false,
+											],
+											"forwarded_ip_config": [],
+										},
+									],
+									"ip_set_reference_statement":            [],
+									"label_match_statement":                 [],
+									"not_statement":                         [],
+									"or_statement":                          [],
+									"rate_based_statement":                  [],
+									"regex_match_statement":                 [],
+									"regex_pattern_set_reference_statement": [],
+									"size_constraint_statement":             [],
+									"sqli_match_statement":                  [],
+									"xss_match_statement":                   [],
+								},
+							],
+							"visibility_config": [
+								{},
+							],
+						},
+					],
+					"tags_all": true,
+					"visibility_config": [
+						{},
+					],
+				},
+				"before":           null,
+				"before_sensitive": false,
+			},
+			"mode":          "managed",
+			"name":          "example",
+			"provider_name": "registry.terraform.io/hashicorp/aws",
+			"type":          "aws_wafv2_rule_group",
+		},
+	],
+	"terraform_version": "1.10.2",
+	"timestamp":         "2025-04-08T06:20:11Z",
+}

--- a/policies/test/wafv2-rulegroup-logging-enabled/mocks/policy-success-cloudwatch-metrics-enabled/mock-tfplan-v2.sentinel
+++ b/policies/test/wafv2-rulegroup-logging-enabled/mocks/policy-success-cloudwatch-metrics-enabled/mock-tfplan-v2.sentinel
@@ -1,0 +1,670 @@
+terraform_version = "1.10.2"
+
+planned_values = {
+	"outputs": {},
+	"resources": {
+		"aws_wafv2_rule_group.example": {
+			"address":        "aws_wafv2_rule_group.example",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "example",
+			"provider_name":  "registry.terraform.io/hashicorp/aws",
+			"tainted":        false,
+			"type":           "aws_wafv2_rule_group",
+			"values": {
+				"capacity":             2,
+				"custom_response_body": [],
+				"description":          null,
+				"name":                 "example-rule",
+				"rule": [
+					{
+						"action": [
+							{
+								"allow": [
+									{
+										"custom_request_handling": [],
+									},
+								],
+								"block":     [],
+								"captcha":   [],
+								"challenge": [],
+								"count":     [],
+							},
+						],
+						"captcha_config": [],
+						"name":           "rule-1",
+						"priority":       1,
+						"rule_label":     [],
+						"statement": [
+							{
+								"and_statement":        [],
+								"byte_match_statement": [],
+								"geo_match_statement": [
+									{
+										"country_codes": [
+											"US",
+											"NL",
+										],
+										"forwarded_ip_config": [],
+									},
+								],
+								"ip_set_reference_statement":            [],
+								"label_match_statement":                 [],
+								"not_statement":                         [],
+								"or_statement":                          [],
+								"rate_based_statement":                  [],
+								"regex_match_statement":                 [],
+								"regex_pattern_set_reference_statement": [],
+								"size_constraint_statement":             [],
+								"sqli_match_statement":                  [],
+								"xss_match_statement":                   [],
+							},
+						],
+						"visibility_config": [
+							{
+								"cloudwatch_metrics_enabled": false,
+								"metric_name":                "friendly-rule-metric-name",
+								"sampled_requests_enabled":   false,
+							},
+						],
+					},
+				],
+				"scope": "REGIONAL",
+				"tags":  null,
+				"visibility_config": [
+					{
+						"cloudwatch_metrics_enabled": true,
+						"metric_name":                "friendly-metric-name",
+						"sampled_requests_enabled":   false,
+					},
+				],
+			},
+		},
+	},
+}
+
+variables = {}
+
+resource_changes = {
+	"aws_wafv2_rule_group.example": {
+		"address": "aws_wafv2_rule_group.example",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"capacity":             2,
+				"custom_response_body": [],
+				"description":          null,
+				"name":                 "example-rule",
+				"rule": [
+					{
+						"action": [
+							{
+								"allow": [
+									{
+										"custom_request_handling": [],
+									},
+								],
+								"block":     [],
+								"captcha":   [],
+								"challenge": [],
+								"count":     [],
+							},
+						],
+						"captcha_config": [],
+						"name":           "rule-1",
+						"priority":       1,
+						"rule_label":     [],
+						"statement": [
+							{
+								"and_statement":        [],
+								"byte_match_statement": [],
+								"geo_match_statement": [
+									{
+										"country_codes": [
+											"US",
+											"NL",
+										],
+										"forwarded_ip_config": [],
+									},
+								],
+								"ip_set_reference_statement":            [],
+								"label_match_statement":                 [],
+								"not_statement":                         [],
+								"or_statement":                          [],
+								"rate_based_statement":                  [],
+								"regex_match_statement":                 [],
+								"regex_pattern_set_reference_statement": [],
+								"size_constraint_statement":             [],
+								"sqli_match_statement":                  [],
+								"xss_match_statement":                   [],
+							},
+						],
+						"visibility_config": [
+							{
+								"cloudwatch_metrics_enabled": false,
+								"metric_name":                "friendly-rule-metric-name",
+								"sampled_requests_enabled":   false,
+							},
+						],
+					},
+				],
+				"scope": "REGIONAL",
+				"tags":  null,
+				"visibility_config": [
+					{
+						"cloudwatch_metrics_enabled": true,
+						"metric_name":                "friendly-metric-name",
+						"sampled_requests_enabled":   false,
+					},
+				],
+			},
+			"after_unknown": {
+				"arn": true,
+				"custom_response_body": [],
+				"id":          true,
+				"lock_token":  true,
+				"name_prefix": true,
+				"rule": [
+					{
+						"action": [
+							{
+								"allow": [
+									{
+										"custom_request_handling": [],
+									},
+								],
+								"block":     [],
+								"captcha":   [],
+								"challenge": [],
+								"count":     [],
+							},
+						],
+						"captcha_config": [],
+						"rule_label":     [],
+						"statement": [
+							{
+								"and_statement":        [],
+								"byte_match_statement": [],
+								"geo_match_statement": [
+									{
+										"country_codes": [
+											false,
+											false,
+										],
+										"forwarded_ip_config": [],
+									},
+								],
+								"ip_set_reference_statement":            [],
+								"label_match_statement":                 [],
+								"not_statement":                         [],
+								"or_statement":                          [],
+								"rate_based_statement":                  [],
+								"regex_match_statement":                 [],
+								"regex_pattern_set_reference_statement": [],
+								"size_constraint_statement":             [],
+								"sqli_match_statement":                  [],
+								"xss_match_statement":                   [],
+							},
+						],
+						"visibility_config": [
+							{},
+						],
+					},
+				],
+				"tags_all": true,
+				"visibility_config": [
+					{},
+				],
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "example",
+		"provider_name":  "registry.terraform.io/hashicorp/aws",
+		"type":           "aws_wafv2_rule_group",
+	},
+}
+
+resource_drift = {}
+
+output_changes = {}
+
+raw = {
+	"complete": true,
+	"configuration": {
+		"provider_config": {
+			"aws": {
+				"expressions": {
+					"region": {
+						"constant_value": "us-east-1",
+					},
+				},
+				"full_name": "registry.terraform.io/hashicorp/aws",
+				"name":      "aws",
+			},
+		},
+		"root_module": {
+			"resources": [
+				{
+					"address": "aws_wafv2_rule_group.example",
+					"expressions": {
+						"capacity": {
+							"constant_value": 2,
+						},
+						"name": {
+							"constant_value": "example-rule",
+						},
+						"rule": [
+							{
+								"action": [
+									{
+										"allow": [
+											{},
+										],
+									},
+								],
+								"name": {
+									"constant_value": "rule-1",
+								},
+								"priority": {
+									"constant_value": 1,
+								},
+								"statement": [
+									{
+										"geo_match_statement": [
+											{
+												"country_codes": {
+													"constant_value": [
+														"US",
+														"NL",
+													],
+												},
+											},
+										],
+									},
+								],
+								"visibility_config": [
+									{
+										"cloudwatch_metrics_enabled": {
+											"constant_value": false,
+										},
+										"metric_name": {
+											"constant_value": "friendly-rule-metric-name",
+										},
+										"sampled_requests_enabled": {
+											"constant_value": false,
+										},
+									},
+								],
+							},
+						],
+						"scope": {
+							"constant_value": "REGIONAL",
+						},
+						"visibility_config": [
+							{
+								"cloudwatch_metrics_enabled": {
+									"constant_value": true,
+								},
+								"metric_name": {
+									"constant_value": "friendly-metric-name",
+								},
+								"sampled_requests_enabled": {
+									"constant_value": false,
+								},
+							},
+						],
+					},
+					"mode":                "managed",
+					"name":                "example",
+					"provider_config_key": "aws",
+					"schema_version":      0,
+					"type":                "aws_wafv2_rule_group",
+				},
+			],
+		},
+	},
+	"format_version": "1.2",
+	"planned_values": {
+		"root_module": {
+			"resources": [
+				{
+					"address":        "aws_wafv2_rule_group.example",
+					"mode":           "managed",
+					"name":           "example",
+					"provider_name":  "registry.terraform.io/hashicorp/aws",
+					"schema_version": 0,
+					"sensitive_values": {
+						"custom_response_body": [],
+						"rule": [
+							{
+								"action": [
+									{
+										"allow": [
+											{
+												"custom_request_handling": [],
+											},
+										],
+										"block":     [],
+										"captcha":   [],
+										"challenge": [],
+										"count":     [],
+									},
+								],
+								"captcha_config": [],
+								"rule_label":     [],
+								"statement": [
+									{
+										"and_statement":        [],
+										"byte_match_statement": [],
+										"geo_match_statement": [
+											{
+												"country_codes": [
+													false,
+													false,
+												],
+												"forwarded_ip_config": [],
+											},
+										],
+										"ip_set_reference_statement":            [],
+										"label_match_statement":                 [],
+										"not_statement":                         [],
+										"or_statement":                          [],
+										"rate_based_statement":                  [],
+										"regex_match_statement":                 [],
+										"regex_pattern_set_reference_statement": [],
+										"size_constraint_statement":             [],
+										"sqli_match_statement":                  [],
+										"xss_match_statement":                   [],
+									},
+								],
+								"visibility_config": [
+									{},
+								],
+							},
+						],
+						"tags_all": {},
+						"visibility_config": [
+							{},
+						],
+					},
+					"type": "aws_wafv2_rule_group",
+					"values": {
+						"capacity":             2,
+						"custom_response_body": [],
+						"description":          null,
+						"name":                 "example-rule",
+						"rule": [
+							{
+								"action": [
+									{
+										"allow": [
+											{
+												"custom_request_handling": [],
+											},
+										],
+										"block":     [],
+										"captcha":   [],
+										"challenge": [],
+										"count":     [],
+									},
+								],
+								"captcha_config": [],
+								"name":           "rule-1",
+								"priority":       1,
+								"rule_label":     [],
+								"statement": [
+									{
+										"and_statement":        [],
+										"byte_match_statement": [],
+										"geo_match_statement": [
+											{
+												"country_codes": [
+													"US",
+													"NL",
+												],
+												"forwarded_ip_config": [],
+											},
+										],
+										"ip_set_reference_statement":            [],
+										"label_match_statement":                 [],
+										"not_statement":                         [],
+										"or_statement":                          [],
+										"rate_based_statement":                  [],
+										"regex_match_statement":                 [],
+										"regex_pattern_set_reference_statement": [],
+										"size_constraint_statement":             [],
+										"sqli_match_statement":                  [],
+										"xss_match_statement":                   [],
+									},
+								],
+								"visibility_config": [
+									{
+										"cloudwatch_metrics_enabled": false,
+										"metric_name":                "friendly-rule-metric-name",
+										"sampled_requests_enabled":   false,
+									},
+								],
+							},
+						],
+						"scope": "REGIONAL",
+						"tags":  null,
+						"visibility_config": [
+							{
+								"cloudwatch_metrics_enabled": true,
+								"metric_name":                "friendly-metric-name",
+								"sampled_requests_enabled":   false,
+							},
+						],
+					},
+				},
+			],
+		},
+	},
+	"resource_changes": [
+		{
+			"address": "aws_wafv2_rule_group.example",
+			"change": {
+				"actions": [
+					"create",
+				],
+				"after": {
+					"capacity":             2,
+					"custom_response_body": [],
+					"description":          null,
+					"name":                 "example-rule",
+					"rule": [
+						{
+							"action": [
+								{
+									"allow": [
+										{
+											"custom_request_handling": [],
+										},
+									],
+									"block":     [],
+									"captcha":   [],
+									"challenge": [],
+									"count":     [],
+								},
+							],
+							"captcha_config": [],
+							"name":           "rule-1",
+							"priority":       1,
+							"rule_label":     [],
+							"statement": [
+								{
+									"and_statement":        [],
+									"byte_match_statement": [],
+									"geo_match_statement": [
+										{
+											"country_codes": [
+												"US",
+												"NL",
+											],
+											"forwarded_ip_config": [],
+										},
+									],
+									"ip_set_reference_statement":            [],
+									"label_match_statement":                 [],
+									"not_statement":                         [],
+									"or_statement":                          [],
+									"rate_based_statement":                  [],
+									"regex_match_statement":                 [],
+									"regex_pattern_set_reference_statement": [],
+									"size_constraint_statement":             [],
+									"sqli_match_statement":                  [],
+									"xss_match_statement":                   [],
+								},
+							],
+							"visibility_config": [
+								{
+									"cloudwatch_metrics_enabled": false,
+									"metric_name":                "friendly-rule-metric-name",
+									"sampled_requests_enabled":   false,
+								},
+							],
+						},
+					],
+					"scope": "REGIONAL",
+					"tags":  null,
+					"visibility_config": [
+						{
+							"cloudwatch_metrics_enabled": true,
+							"metric_name":                "friendly-metric-name",
+							"sampled_requests_enabled":   false,
+						},
+					],
+				},
+				"after_sensitive": {
+					"custom_response_body": [],
+					"rule": [
+						{
+							"action": [
+								{
+									"allow": [
+										{
+											"custom_request_handling": [],
+										},
+									],
+									"block":     [],
+									"captcha":   [],
+									"challenge": [],
+									"count":     [],
+								},
+							],
+							"captcha_config": [],
+							"rule_label":     [],
+							"statement": [
+								{
+									"and_statement":        [],
+									"byte_match_statement": [],
+									"geo_match_statement": [
+										{
+											"country_codes": [
+												false,
+												false,
+											],
+											"forwarded_ip_config": [],
+										},
+									],
+									"ip_set_reference_statement":            [],
+									"label_match_statement":                 [],
+									"not_statement":                         [],
+									"or_statement":                          [],
+									"rate_based_statement":                  [],
+									"regex_match_statement":                 [],
+									"regex_pattern_set_reference_statement": [],
+									"size_constraint_statement":             [],
+									"sqli_match_statement":                  [],
+									"xss_match_statement":                   [],
+								},
+							],
+							"visibility_config": [
+								{},
+							],
+						},
+					],
+					"tags_all": {},
+					"visibility_config": [
+						{},
+					],
+				},
+				"after_unknown": {
+					"arn": true,
+					"custom_response_body": [],
+					"id":          true,
+					"lock_token":  true,
+					"name_prefix": true,
+					"rule": [
+						{
+							"action": [
+								{
+									"allow": [
+										{
+											"custom_request_handling": [],
+										},
+									],
+									"block":     [],
+									"captcha":   [],
+									"challenge": [],
+									"count":     [],
+								},
+							],
+							"captcha_config": [],
+							"rule_label":     [],
+							"statement": [
+								{
+									"and_statement":        [],
+									"byte_match_statement": [],
+									"geo_match_statement": [
+										{
+											"country_codes": [
+												false,
+												false,
+											],
+											"forwarded_ip_config": [],
+										},
+									],
+									"ip_set_reference_statement":            [],
+									"label_match_statement":                 [],
+									"not_statement":                         [],
+									"or_statement":                          [],
+									"rate_based_statement":                  [],
+									"regex_match_statement":                 [],
+									"regex_pattern_set_reference_statement": [],
+									"size_constraint_statement":             [],
+									"sqli_match_statement":                  [],
+									"xss_match_statement":                   [],
+								},
+							],
+							"visibility_config": [
+								{},
+							],
+						},
+					],
+					"tags_all": true,
+					"visibility_config": [
+						{},
+					],
+				},
+				"before":           null,
+				"before_sensitive": false,
+			},
+			"mode":          "managed",
+			"name":          "example",
+			"provider_name": "registry.terraform.io/hashicorp/aws",
+			"type":          "aws_wafv2_rule_group",
+		},
+	],
+	"terraform_version": "1.10.2",
+	"timestamp":         "2025-04-08T06:22:56Z",
+}

--- a/policies/test/wafv2-rulegroup-logging-enabled/success-cloudwatch-metrics-enabled.hcl
+++ b/policies/test/wafv2-rulegroup-logging-enabled/success-cloudwatch-metrics-enabled.hcl
@@ -1,0 +1,23 @@
+mock "tfplan/v2" {
+	module {
+		source = "./mocks/policy-success-cloudwatch-metrics-enabled/mock-tfplan-v2.sentinel"
+	}
+}
+
+
+
+import "plugin" "tfresources" {
+	source = "../../../plugins/darwin/arm64/sentinel-plugin-tfresources"
+}
+
+mock "report" {
+	module {
+		source = "../../../modules/mocks/report/report.sentinel"
+	}
+}
+
+test {
+	rules = {
+		main = true
+	}
+}

--- a/policies/wafv2-rulegroup-logging-enabled.sentinel
+++ b/policies/wafv2-rulegroup-logging-enabled.sentinel
@@ -1,0 +1,51 @@
+# This policy requires resources of type `aws_wafv2_rule_group` have attribute 'cloudwatch_metrics_enabled' set to true.
+
+# Imports
+
+import "tfplan/v2" as tfplan
+import "tfresources" as tf
+import "report" as report
+import "collection" as collection
+import "collection/maps" as maps
+
+# Constants
+
+const = {
+	"policy_name":                   "wafv2-rulegroup-logging-enabled",
+	"message":                       "Attribute 'visibility_config.cloudwatch_metrics_enabled' must be set to true for 'aws_wafv2_rule_group' resources. Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/waf-controls.html#waf-12 for more details.",
+	"resource_aws_wafv2_rule_group": "aws_wafv2_rule_group",
+	"visibility_config":             "visibility_config",
+	"cloudwatch_metrics_enabled":    "cloudwatch_metrics_enabled",
+}
+
+# Variables
+
+resources = tf.plan(tfplan.planned_values.resources).type(const.resource_aws_wafv2_rule_group).resources
+violations = collection.reject(resources, func(res) {
+	visibility_config = maps.get(res.values, const.visibility_config, null)
+	if visibility_config is null {
+		return true
+	}
+	return maps.get(visibility_config[0], const.cloudwatch_metrics_enabled, false) is true
+})
+
+summary = {
+	"policy_name": const.policy_name,
+	"violations": map violations as _, v {
+		{
+			"address":        v.address,
+			"module_address": v.module_address,
+			"message":        const.message,
+		}
+	},
+}
+
+# Outputs
+
+print(report.generate_policy_report(summary))
+
+# Rules
+
+main = rule {
+	violations is empty
+}

--- a/sentinel.hcl
+++ b/sentinel.hcl
@@ -973,3 +973,8 @@ policy "kinesis-firehose-delivery-stream-encrypted" {
   source = "./policies/kinesis-firehose-delivery-stream-encrypted.sentinel"
   enforcement_level = "advisory"
 }
+
+policy "wafv2-rulegroup-logging-enabled" {
+  source = "./policies/wafv2-rulegroup-logging-enabled.sentinel"
+  enforcement_level = "advisory"
+}

--- a/tests/acceptance/wafv2-rulegroup-logging-enabled/cases/cloudwatch-metrics-disabled/backend.tf
+++ b/tests/acceptance/wafv2-rulegroup-logging-enabled/cases/cloudwatch-metrics-disabled/backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  cloud {
+    workspaces {
+      name = "wafv2-rulegroup-logging-enabled"
+    }
+  }
+}

--- a/tests/acceptance/wafv2-rulegroup-logging-enabled/cases/cloudwatch-metrics-disabled/main.tf
+++ b/tests/acceptance/wafv2-rulegroup-logging-enabled/cases/cloudwatch-metrics-disabled/main.tf
@@ -1,0 +1,37 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+resource "aws_wafv2_rule_group" "example" {
+  name     = "example-rule"
+  scope    = "REGIONAL"
+  capacity = 2
+
+  rule {
+    name     = "rule-1"
+    priority = 1
+
+    action {
+      allow {}
+    }
+
+    statement {
+
+      geo_match_statement {
+        country_codes = ["US", "NL"]
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = false
+      metric_name                = "friendly-rule-metric-name"
+      sampled_requests_enabled   = false
+    }
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = false
+    metric_name                = "friendly-metric-name"
+    sampled_requests_enabled   = false
+  }
+}

--- a/tests/acceptance/wafv2-rulegroup-logging-enabled/cases/cloudwatch-metrics-enabled/backend.tf
+++ b/tests/acceptance/wafv2-rulegroup-logging-enabled/cases/cloudwatch-metrics-enabled/backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  cloud {
+    workspaces {
+      name = "wafv2-rulegroup-logging-enabled"
+    }
+  }
+}

--- a/tests/acceptance/wafv2-rulegroup-logging-enabled/cases/cloudwatch-metrics-enabled/main.tf
+++ b/tests/acceptance/wafv2-rulegroup-logging-enabled/cases/cloudwatch-metrics-enabled/main.tf
@@ -1,0 +1,37 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+resource "aws_wafv2_rule_group" "example" {
+  name     = "example-rule"
+  scope    = "REGIONAL"
+  capacity = 2
+
+  rule {
+    name     = "rule-1"
+    priority = 1
+
+    action {
+      allow {}
+    }
+
+    statement {
+
+      geo_match_statement {
+        country_codes = ["US", "NL"]
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = false
+      metric_name                = "friendly-rule-metric-name"
+      sampled_requests_enabled   = false
+    }
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = true
+    metric_name                = "friendly-metric-name"
+    sampled_requests_enabled   = false
+  }
+}

--- a/tests/acceptance/wafv2-rulegroup-logging-enabled/test-config.hcl
+++ b/tests/acceptance/wafv2-rulegroup-logging-enabled/test-config.hcl
@@ -1,0 +1,17 @@
+name = "wafv2-rulegroup-logging-enabled"
+
+disabled = false
+
+case "WAFv2 Rule Group Logging Enabled" {
+    path = "./cases/cloudwatch-metrics-enabled"
+    expectation {
+        result = true
+    }
+}
+
+case "WAFv2 Rule Group Logging Disabled" {
+    path = "./cases/cloudwatch-metrics-disabled"
+    expectation {
+        result = false
+    }
+}


### PR DESCRIPTION
## Changes proposed in this PR:
- Added wafv2-rulegroup-logging-enabled

## Documentation
- [AWS Standard](https://docs.aws.amazon.com/securityhub/latest/userguide/waf-controls.html#waf-12)
- [Policy details](https://docs.aws.amazon.com/securityhub/latest/userguide/waf-controls.html#waf-12)

## AWS Provider version
<!-- Add information about the provider version against which the policy was tested/developed with. This will later help us when we deal with documentation.Add any nuances that you've observed around provider versions. For example, some attributes will only be present in a certain version of a provider and we need to clearly document that so that users use the expected version.-->

## How I've tested this PR:

## Checklist:
- [ ] Tests added