### PR TITLE
Add waf-regional-webacl-not-empty

### DIFF
--- a/docs/policies/waf-regional-webacl-not-empty.md
+++ b/docs/policies/waf-regional-webacl-not-empty.md
@@ -1,0 +1,67 @@
+# AWS WAF Classic Regional web ACLs should have at least one rule or rule group
+
+| Provider            | Category                     |
+|---------------------|------------------------------|
+| Amazon Web Services | Secure network configuration |
+
+## Description
+
+This control checks whether an AWS WAF Classic Regional web ACL contains any WAF rules or WAF rule groups. This control fails if a web ACL does not contain any WAF rules or rule groups.
+
+A WAF Regional web ACL can contain a collection of rules and rule groups that inspect and control web requests. If a web ACL is empty, the web traffic can pass without being detected or acted upon by WAF depending on the default action.
+
+This rule is covered by the [waf-regional-webacl-not-empty](../../policies/waf-regional-webacl-not-empty.sentinel) policy.
+
+## Policy Results (Pass)
+```bash
+trace:
+      Pass - waf-regional-webacl-not-empty.sentinel
+
+      Description:
+        This policy requires resources of type `aws_wafregional_web_acl` to have at
+        least one rule or rule group.
+
+      Print messages:
+
+      → → Overall Result: true
+
+      This result means that all resources have passed the policy check for the policy waf-regional-webacl-not-empty.
+
+      ✓ Found 0 resource violations
+
+      waf-regional-webacl-not-empty.sentinel:44:1 - Rule "main"
+        Value:
+          true
+```
+
+---
+
+## Policy Results (Fail)
+```bash
+trace:
+      Fail - waf-regional-webacl-not-empty.sentinel
+
+      Description:
+        This policy requires resources of type `aws_wafregional_web_acl` to have at
+        least one rule or rule group.
+
+      Print messages:
+
+      → → Overall Result: false
+
+      This result means that not all resources passed the policy check and the protected behavior is not allowed for the policy waf-regional-webacl-not-empty.
+
+      Found 1 resource violations
+
+      → Module name: root
+        ↳ Resource Address: aws_wafregional_web_acl.wafacl
+          | ✗ failed
+          | AWS WAF Classic Regional web ACLs should have at least one rule or rule group. Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/waf-controls.html#waf-4 for more details.
+
+
+      waf-regional-webacl-not-empty.sentinel:44:1 - Rule "main"
+        Value:
+          false
+```
+
+---

--- a/policies/test/waf-regional-webacl-not-empty/failure-rules-are-empty.hcl
+++ b/policies/test/waf-regional-webacl-not-empty/failure-rules-are-empty.hcl
@@ -1,0 +1,23 @@
+mock "tfplan/v2" {
+	module {
+		source = "./mocks/policy-failure-rules-are-empty/mock-tfplan-v2.sentinel"
+	}
+}
+
+
+
+import "plugin" "tfresources" {
+	source = "../../../plugins/darwin/arm64/sentinel-plugin-tfresources"
+}
+
+mock "report" {
+	module {
+		source = "../../../modules/mocks/report/report.sentinel"
+	}
+}
+
+test {
+	rules = {
+		main = false
+	}
+}

--- a/policies/test/waf-regional-webacl-not-empty/mocks/policy-failure-rules-are-empty/mock-tfplan-v2.sentinel
+++ b/policies/test/waf-regional-webacl-not-empty/mocks/policy-failure-rules-are-empty/mock-tfplan-v2.sentinel
@@ -1,0 +1,205 @@
+terraform_version = "1.10.2"
+
+planned_values = {
+	"outputs": {},
+	"resources": {
+		"aws_wafregional_web_acl.wafacl": {
+			"address":        "aws_wafregional_web_acl.wafacl",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "wafacl",
+			"provider_name":  "registry.terraform.io/hashicorp/aws",
+			"tainted":        false,
+			"type":           "aws_wafregional_web_acl",
+			"values": {
+				"default_action": [
+					{
+						"type": "ALLOW",
+					},
+				],
+				"logging_configuration": [],
+				"metric_name":           "tfWebACL",
+				"name":                  "tfWebACL",
+				"rule":                  [],
+				"tags":                  null,
+			},
+		},
+	},
+}
+
+variables = {}
+
+resource_changes = {
+	"aws_wafregional_web_acl.wafacl": {
+		"address": "aws_wafregional_web_acl.wafacl",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"default_action": [
+					{
+						"type": "ALLOW",
+					},
+				],
+				"logging_configuration": [],
+				"metric_name":           "tfWebACL",
+				"name":                  "tfWebACL",
+				"rule":                  [],
+				"tags":                  null,
+			},
+			"after_unknown": {
+				"arn": true,
+				"default_action": [
+					{},
+				],
+				"id": true,
+				"logging_configuration": [],
+				"rule":                  [],
+				"tags_all":              true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "wafacl",
+		"provider_name":  "registry.terraform.io/hashicorp/aws",
+		"type":           "aws_wafregional_web_acl",
+	},
+}
+
+resource_drift = {}
+
+output_changes = {}
+
+raw = {
+	"complete": true,
+	"configuration": {
+		"provider_config": {
+			"aws": {
+				"expressions": {
+					"region": {
+						"constant_value": "us-east-1",
+					},
+				},
+				"full_name": "registry.terraform.io/hashicorp/aws",
+				"name":      "aws",
+			},
+		},
+		"root_module": {
+			"resources": [
+				{
+					"address": "aws_wafregional_web_acl.wafacl",
+					"expressions": {
+						"default_action": [
+							{
+								"type": {
+									"constant_value": "ALLOW",
+								},
+							},
+						],
+						"metric_name": {
+							"constant_value": "tfWebACL",
+						},
+						"name": {
+							"constant_value": "tfWebACL",
+						},
+					},
+					"mode":                "managed",
+					"name":                "wafacl",
+					"provider_config_key": "aws",
+					"schema_version":      0,
+					"type":                "aws_wafregional_web_acl",
+				},
+			],
+		},
+	},
+	"format_version": "1.2",
+	"planned_values": {
+		"root_module": {
+			"resources": [
+				{
+					"address":        "aws_wafregional_web_acl.wafacl",
+					"mode":           "managed",
+					"name":           "wafacl",
+					"provider_name":  "registry.terraform.io/hashicorp/aws",
+					"schema_version": 0,
+					"sensitive_values": {
+						"default_action": [
+							{},
+						],
+						"logging_configuration": [],
+						"rule":                  [],
+						"tags_all":              {},
+					},
+					"type": "aws_wafregional_web_acl",
+					"values": {
+						"default_action": [
+							{
+								"type": "ALLOW",
+							},
+						],
+						"logging_configuration": [],
+						"metric_name":           "tfWebACL",
+						"name":                  "tfWebACL",
+						"rule":                  [],
+						"tags":                  null,
+					},
+				},
+			],
+		},
+	},
+	"resource_changes": [
+		{
+			"address": "aws_wafregional_web_acl.wafacl",
+			"change": {
+				"actions": [
+					"create",
+				],
+				"after": {
+					"default_action": [
+						{
+							"type": "ALLOW",
+						},
+					],
+					"logging_configuration": [],
+					"metric_name":           "tfWebACL",
+					"name":                  "tfWebACL",
+					"rule":                  [],
+					"tags":                  null,
+				},
+				"after_sensitive": {
+					"default_action": [
+						{},
+					],
+					"logging_configuration": [],
+					"rule":                  [],
+					"tags_all":              {},
+				},
+				"after_unknown": {
+					"arn": true,
+					"default_action": [
+						{},
+					],
+					"id": true,
+					"logging_configuration": [],
+					"rule":                  [],
+					"tags_all":              true,
+				},
+				"before":           null,
+				"before_sensitive": false,
+			},
+			"mode":          "managed",
+			"name":          "wafacl",
+			"provider_name": "registry.terraform.io/hashicorp/aws",
+			"type":          "aws_wafregional_web_acl",
+		},
+	],
+	"terraform_version": "1.10.2",
+	"timestamp":         "2025-04-07T13:06:12Z",
+}

--- a/policies/test/waf-regional-webacl-not-empty/mocks/policy-success-rules-are-not-empty/mock-tfplan-v2.sentinel
+++ b/policies/test/waf-regional-webacl-not-empty/mocks/policy-success-rules-are-not-empty/mock-tfplan-v2.sentinel
@@ -1,0 +1,607 @@
+terraform_version = "1.10.2"
+
+planned_values = {
+	"outputs": {},
+	"resources": {
+		"aws_wafregional_ipset.ipset": {
+			"address":        "aws_wafregional_ipset.ipset",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "ipset",
+			"provider_name":  "registry.terraform.io/hashicorp/aws",
+			"tainted":        false,
+			"type":           "aws_wafregional_ipset",
+			"values": {
+				"ip_set_descriptor": [
+					{
+						"type":  "IPV4",
+						"value": "192.0.7.0/24",
+					},
+				],
+				"name": "tfIPSet",
+			},
+		},
+		"aws_wafregional_rule.wafrule": {
+			"address":        "aws_wafregional_rule.wafrule",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "wafrule",
+			"provider_name":  "registry.terraform.io/hashicorp/aws",
+			"tainted":        false,
+			"type":           "aws_wafregional_rule",
+			"values": {
+				"metric_name": "tfWAFRule",
+				"name":        "tfWAFRule",
+				"predicate": [
+					{
+						"negated": false,
+						"type":    "IPMatch",
+					},
+				],
+				"tags": null,
+			},
+		},
+		"aws_wafregional_web_acl.wafacl": {
+			"address":        "aws_wafregional_web_acl.wafacl",
+			"depends_on":     [],
+			"deposed_key":    "",
+			"index":          null,
+			"mode":           "managed",
+			"module_address": "",
+			"name":           "wafacl",
+			"provider_name":  "registry.terraform.io/hashicorp/aws",
+			"tainted":        false,
+			"type":           "aws_wafregional_web_acl",
+			"values": {
+				"default_action": [
+					{
+						"type": "ALLOW",
+					},
+				],
+				"logging_configuration": [],
+				"metric_name":           "tfWebACL",
+				"name":                  "tfWebACL",
+				"rule": [
+					{
+						"action": [
+							{
+								"type": "BLOCK",
+							},
+						],
+						"override_action": [],
+						"priority":        1,
+						"type":            "REGULAR",
+					},
+				],
+				"tags": null,
+			},
+		},
+	},
+}
+
+variables = {}
+
+resource_changes = {
+	"aws_wafregional_ipset.ipset": {
+		"address": "aws_wafregional_ipset.ipset",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"ip_set_descriptor": [
+					{
+						"type":  "IPV4",
+						"value": "192.0.7.0/24",
+					},
+				],
+				"name": "tfIPSet",
+			},
+			"after_unknown": {
+				"arn": true,
+				"id":  true,
+				"ip_set_descriptor": [
+					{},
+				],
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "ipset",
+		"provider_name":  "registry.terraform.io/hashicorp/aws",
+		"type":           "aws_wafregional_ipset",
+	},
+	"aws_wafregional_rule.wafrule": {
+		"address": "aws_wafregional_rule.wafrule",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"metric_name": "tfWAFRule",
+				"name":        "tfWAFRule",
+				"predicate": [
+					{
+						"negated": false,
+						"type":    "IPMatch",
+					},
+				],
+				"tags": null,
+			},
+			"after_unknown": {
+				"arn": true,
+				"id":  true,
+				"predicate": [
+					{
+						"data_id": true,
+					},
+				],
+				"tags_all": true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "wafrule",
+		"provider_name":  "registry.terraform.io/hashicorp/aws",
+		"type":           "aws_wafregional_rule",
+	},
+	"aws_wafregional_web_acl.wafacl": {
+		"address": "aws_wafregional_web_acl.wafacl",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"default_action": [
+					{
+						"type": "ALLOW",
+					},
+				],
+				"logging_configuration": [],
+				"metric_name":           "tfWebACL",
+				"name":                  "tfWebACL",
+				"rule": [
+					{
+						"action": [
+							{
+								"type": "BLOCK",
+							},
+						],
+						"override_action": [],
+						"priority":        1,
+						"type":            "REGULAR",
+					},
+				],
+				"tags": null,
+			},
+			"after_unknown": {
+				"arn": true,
+				"default_action": [
+					{},
+				],
+				"id": true,
+				"logging_configuration": [],
+				"rule": [
+					{
+						"action": [
+							{},
+						],
+						"override_action": [],
+						"rule_id":         true,
+					},
+				],
+				"tags_all": true,
+			},
+			"before": null,
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "",
+		"name":           "wafacl",
+		"provider_name":  "registry.terraform.io/hashicorp/aws",
+		"type":           "aws_wafregional_web_acl",
+	},
+}
+
+resource_drift = {}
+
+output_changes = {}
+
+raw = {
+	"complete": true,
+	"configuration": {
+		"provider_config": {
+			"aws": {
+				"expressions": {
+					"region": {
+						"constant_value": "us-east-1",
+					},
+				},
+				"full_name": "registry.terraform.io/hashicorp/aws",
+				"name":      "aws",
+			},
+		},
+		"root_module": {
+			"resources": [
+				{
+					"address": "aws_wafregional_ipset.ipset",
+					"expressions": {
+						"ip_set_descriptor": [
+							{
+								"type": {
+									"constant_value": "IPV4",
+								},
+								"value": {
+									"constant_value": "192.0.7.0/24",
+								},
+							},
+						],
+						"name": {
+							"constant_value": "tfIPSet",
+						},
+					},
+					"mode":                "managed",
+					"name":                "ipset",
+					"provider_config_key": "aws",
+					"schema_version":      0,
+					"type":                "aws_wafregional_ipset",
+				},
+				{
+					"address": "aws_wafregional_rule.wafrule",
+					"expressions": {
+						"metric_name": {
+							"constant_value": "tfWAFRule",
+						},
+						"name": {
+							"constant_value": "tfWAFRule",
+						},
+						"predicate": [
+							{
+								"data_id": {
+									"references": [
+										"aws_wafregional_ipset.ipset.id",
+										"aws_wafregional_ipset.ipset",
+									],
+								},
+								"negated": {
+									"constant_value": false,
+								},
+								"type": {
+									"constant_value": "IPMatch",
+								},
+							},
+						],
+					},
+					"mode":                "managed",
+					"name":                "wafrule",
+					"provider_config_key": "aws",
+					"schema_version":      0,
+					"type":                "aws_wafregional_rule",
+				},
+				{
+					"address": "aws_wafregional_web_acl.wafacl",
+					"expressions": {
+						"default_action": [
+							{
+								"type": {
+									"constant_value": "ALLOW",
+								},
+							},
+						],
+						"metric_name": {
+							"constant_value": "tfWebACL",
+						},
+						"name": {
+							"constant_value": "tfWebACL",
+						},
+						"rule": [
+							{
+								"action": [
+									{
+										"type": {
+											"constant_value": "BLOCK",
+										},
+									},
+								],
+								"priority": {
+									"constant_value": 1,
+								},
+								"rule_id": {
+									"references": [
+										"aws_wafregional_rule.wafrule.id",
+										"aws_wafregional_rule.wafrule",
+									],
+								},
+								"type": {
+									"constant_value": "REGULAR",
+								},
+							},
+						],
+					},
+					"mode":                "managed",
+					"name":                "wafacl",
+					"provider_config_key": "aws",
+					"schema_version":      0,
+					"type":                "aws_wafregional_web_acl",
+				},
+			],
+		},
+	},
+	"format_version": "1.2",
+	"planned_values": {
+		"root_module": {
+			"resources": [
+				{
+					"address":        "aws_wafregional_ipset.ipset",
+					"mode":           "managed",
+					"name":           "ipset",
+					"provider_name":  "registry.terraform.io/hashicorp/aws",
+					"schema_version": 0,
+					"sensitive_values": {
+						"ip_set_descriptor": [
+							{},
+						],
+					},
+					"type": "aws_wafregional_ipset",
+					"values": {
+						"ip_set_descriptor": [
+							{
+								"type":  "IPV4",
+								"value": "192.0.7.0/24",
+							},
+						],
+						"name": "tfIPSet",
+					},
+				},
+				{
+					"address":        "aws_wafregional_rule.wafrule",
+					"mode":           "managed",
+					"name":           "wafrule",
+					"provider_name":  "registry.terraform.io/hashicorp/aws",
+					"schema_version": 0,
+					"sensitive_values": {
+						"predicate": [
+							{},
+						],
+						"tags_all": {},
+					},
+					"type": "aws_wafregional_rule",
+					"values": {
+						"metric_name": "tfWAFRule",
+						"name":        "tfWAFRule",
+						"predicate": [
+							{
+								"negated": false,
+								"type":    "IPMatch",
+							},
+						],
+						"tags": null,
+					},
+				},
+				{
+					"address":        "aws_wafregional_web_acl.wafacl",
+					"mode":           "managed",
+					"name":           "wafacl",
+					"provider_name":  "registry.terraform.io/hashicorp/aws",
+					"schema_version": 0,
+					"sensitive_values": {
+						"default_action": [
+							{},
+						],
+						"logging_configuration": [],
+						"rule": [
+							{
+								"action": [
+									{},
+								],
+								"override_action": [],
+							},
+						],
+						"tags_all": {},
+					},
+					"type": "aws_wafregional_web_acl",
+					"values": {
+						"default_action": [
+							{
+								"type": "ALLOW",
+							},
+						],
+						"logging_configuration": [],
+						"metric_name":           "tfWebACL",
+						"name":                  "tfWebACL",
+						"rule": [
+							{
+								"action": [
+									{
+										"type": "BLOCK",
+									},
+								],
+								"override_action": [],
+								"priority":        1,
+								"type":            "REGULAR",
+							},
+						],
+						"tags": null,
+					},
+				},
+			],
+		},
+	},
+	"relevant_attributes": [
+		{
+			"attribute": [
+				"id",
+			],
+			"resource": "aws_wafregional_ipset.ipset",
+		},
+		{
+			"attribute": [
+				"id",
+			],
+			"resource": "aws_wafregional_rule.wafrule",
+		},
+	],
+	"resource_changes": [
+		{
+			"address": "aws_wafregional_ipset.ipset",
+			"change": {
+				"actions": [
+					"create",
+				],
+				"after": {
+					"ip_set_descriptor": [
+						{
+							"type":  "IPV4",
+							"value": "192.0.7.0/24",
+						},
+					],
+					"name": "tfIPSet",
+				},
+				"after_sensitive": {
+					"ip_set_descriptor": [
+						{},
+					],
+				},
+				"after_unknown": {
+					"arn": true,
+					"id":  true,
+					"ip_set_descriptor": [
+						{},
+					],
+				},
+				"before":           null,
+				"before_sensitive": false,
+			},
+			"mode":          "managed",
+			"name":          "ipset",
+			"provider_name": "registry.terraform.io/hashicorp/aws",
+			"type":          "aws_wafregional_ipset",
+		},
+		{
+			"address": "aws_wafregional_rule.wafrule",
+			"change": {
+				"actions": [
+					"create",
+				],
+				"after": {
+					"metric_name": "tfWAFRule",
+					"name":        "tfWAFRule",
+					"predicate": [
+						{
+							"negated": false,
+							"type":    "IPMatch",
+						},
+					],
+					"tags": null,
+				},
+				"after_sensitive": {
+					"predicate": [
+						{},
+					],
+					"tags_all": {},
+				},
+				"after_unknown": {
+					"arn": true,
+					"id":  true,
+					"predicate": [
+						{
+							"data_id": true,
+						},
+					],
+					"tags_all": true,
+				},
+				"before":           null,
+				"before_sensitive": false,
+			},
+			"mode":          "managed",
+			"name":          "wafrule",
+			"provider_name": "registry.terraform.io/hashicorp/aws",
+			"type":          "aws_wafregional_rule",
+		},
+		{
+			"address": "aws_wafregional_web_acl.wafacl",
+			"change": {
+				"actions": [
+					"create",
+				],
+				"after": {
+					"default_action": [
+						{
+							"type": "ALLOW",
+						},
+					],
+					"logging_configuration": [],
+					"metric_name":           "tfWebACL",
+					"name":                  "tfWebACL",
+					"rule": [
+						{
+							"action": [
+								{
+									"type": "BLOCK",
+								},
+							],
+							"override_action": [],
+							"priority":        1,
+							"type":            "REGULAR",
+						},
+					],
+					"tags": null,
+				},
+				"after_sensitive": {
+					"default_action": [
+						{},
+					],
+					"logging_configuration": [],
+					"rule": [
+						{
+							"action": [
+								{},
+							],
+							"override_action": [],
+						},
+					],
+					"tags_all": {},
+				},
+				"after_unknown": {
+					"arn": true,
+					"default_action": [
+						{},
+					],
+					"id": true,
+					"logging_configuration": [],
+					"rule": [
+						{
+							"action": [
+								{},
+							],
+							"override_action": [],
+							"rule_id":         true,
+						},
+					],
+					"tags_all": true,
+				},
+				"before":           null,
+				"before_sensitive": false,
+			},
+			"mode":          "managed",
+			"name":          "wafacl",
+			"provider_name": "registry.terraform.io/hashicorp/aws",
+			"type":          "aws_wafregional_web_acl",
+		},
+	],
+	"terraform_version": "1.10.2",
+	"timestamp":         "2025-04-07T13:08:27Z",
+}

--- a/policies/test/waf-regional-webacl-not-empty/success-rules-are-not-empty.hcl
+++ b/policies/test/waf-regional-webacl-not-empty/success-rules-are-not-empty.hcl
@@ -1,0 +1,23 @@
+mock "tfplan/v2" {
+	module {
+		source = "./mocks/policy-success-rules-are-not-empty/mock-tfplan-v2.sentinel"
+	}
+}
+
+
+
+import "plugin" "tfresources" {
+	source = "../../../plugins/darwin/arm64/sentinel-plugin-tfresources"
+}
+
+mock "report" {
+	module {
+		source = "../../../modules/mocks/report/report.sentinel"
+	}
+}
+
+test {
+	rules = {
+		main = true
+	}
+}

--- a/policies/waf-regional-webacl-not-empty.sentinel
+++ b/policies/waf-regional-webacl-not-empty.sentinel
@@ -1,0 +1,46 @@
+# This policy requires resources of type `aws_wafregional_web_acl` to have at least one rule or rule group.
+
+# Imports
+
+import "tfplan/v2" as tfplan
+import "tfresources" as tf
+import "report" as report
+import "collection" as collection
+import "collection/maps" as maps
+
+# Constants
+
+const = {
+	"policy_name":                      "waf-regional-webacl-not-empty",
+	"message":                          "AWS WAF Classic Regional web ACLs should have at least one rule or rule group. Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/waf-controls.html#waf-4 for more details.",
+	"resource_aws_wafregional_web_acl": "aws_wafregional_web_acl",
+	"rule": "rule",
+}
+
+# Variables
+
+resources = tf.plan(tfplan.planned_values.resources).type(const.resource_aws_wafregional_web_acl).resources
+violations = collection.reject(resources, func(res) {
+	return maps.get(res, "values.rule", []) is not empty
+})
+
+summary = {
+	"policy_name": const.policy_name,
+	"violations": map violations as _, v {
+		{
+			"address":        v.address,
+			"module_address": v.module_address,
+			"message":        const.message,
+		}
+	},
+}
+
+# Outputs
+
+print(report.generate_policy_report(summary))
+
+# Rules
+
+main = rule {
+	violations is empty
+}

--- a/sentinel.hcl
+++ b/sentinel.hcl
@@ -973,3 +973,8 @@ policy "kinesis-firehose-delivery-stream-encrypted" {
   source = "./policies/kinesis-firehose-delivery-stream-encrypted.sentinel"
   enforcement_level = "advisory"
 }
+
+policy "waf-regional-webacl-not-empty" {
+  source = "./policies/waf-regional-webacl-not-empty.sentinel"
+  enforcement_level = "advisory"
+}

--- a/tests/acceptance/waf-regional-webacl-not-empty/cases/rules-are-empty/backend.tf
+++ b/tests/acceptance/waf-regional-webacl-not-empty/cases/rules-are-empty/backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  cloud {
+    workspaces {
+      name = "waf-regional-webacl-not-empty"
+    }
+  }
+}

--- a/tests/acceptance/waf-regional-webacl-not-empty/cases/rules-are-empty/main.tf
+++ b/tests/acceptance/waf-regional-webacl-not-empty/cases/rules-are-empty/main.tf
@@ -1,0 +1,12 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+resource "aws_wafregional_web_acl" "wafacl" {
+  name        = "tfWebACL"
+  metric_name = "tfWebACL"
+
+  default_action {
+    type = "ALLOW"
+  }
+}

--- a/tests/acceptance/waf-regional-webacl-not-empty/cases/rules-are-not-empty/backend.tf
+++ b/tests/acceptance/waf-regional-webacl-not-empty/cases/rules-are-not-empty/backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  cloud {
+    workspaces {
+      name = "waf-regional-webacl-not-empty"
+    }
+  }
+}

--- a/tests/acceptance/waf-regional-webacl-not-empty/cases/rules-are-not-empty/main.tf
+++ b/tests/acceptance/waf-regional-webacl-not-empty/cases/rules-are-not-empty/main.tf
@@ -1,0 +1,42 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+resource "aws_wafregional_ipset" "ipset" {
+  name = "tfIPSet"
+
+  ip_set_descriptor {
+    type  = "IPV4"
+    value = "192.0.7.0/24"
+  }
+}
+
+resource "aws_wafregional_rule" "wafrule" {
+  name        = "tfWAFRule"
+  metric_name = "tfWAFRule"
+
+  predicate {
+    data_id = aws_wafregional_ipset.ipset.id
+    negated = false
+    type    = "IPMatch"
+  }
+}
+
+resource "aws_wafregional_web_acl" "wafacl" {
+  name        = "tfWebACL"
+  metric_name = "tfWebACL"
+
+  default_action {
+    type = "ALLOW"
+  }
+
+  rule {
+    action {
+      type = "BLOCK"
+    }
+
+    priority = 1
+    rule_id  = aws_wafregional_rule.wafrule.id
+    type     = "REGULAR"
+  }
+}

--- a/tests/acceptance/waf-regional-webacl-not-empty/test-config.hcl
+++ b/tests/acceptance/waf-regional-webacl-not-empty/test-config.hcl
@@ -1,0 +1,17 @@
+name = "waf-regional-webacl-not-empty"
+
+disabled = false
+
+case "WAF Regional WebACL Not Empty" {
+    path = "./cases/rules-are-not-empty"
+    expectation {
+        result = true
+    }
+}
+
+case "WAF Regional WebACL Empty" {
+    path = "./cases/rules-are-empty"
+    expectation {
+        result = false
+    }
+}


### PR DESCRIPTION
## Changes proposed in this PR:
- Added waf-regional-webacl-not-empty

## Documentation
- [AWS Standard](https://docs.aws.amazon.com/securityhub/latest/userguide/waf-controls.html#waf-4)
- [Policy details](https://docs.aws.amazon.com/securityhub/latest/userguide/waf-controls.html#waf-4)

## AWS Provider version
<!-- Add information about the provider version against which the policy was tested/developed with. This will later help us when we deal with documentation.Add any nuances that you've observed around provider versions. For example, some attributes will only be present in a certain version of a provider and we need to clearly document that so that users use the expected version.-->

## How I've tested this PR:

## Checklist:
- [x] Tests added