### PR TITLE
Added cloudfront-s3-origin-access-control-enabled

### DIFF
--- a/docs/policies/cloudfront-s3-origin-access-control-enabled.md
+++ b/docs/policies/cloudfront-s3-origin-access-control-enabled.md
@@ -1,0 +1,72 @@
+# CloudFront distributions should use origin access control
+
+| Provider            |         Category         |
+|---------------------| -------------------------|
+| Amazon Web Services | Secure access management |
+
+## Description
+
+DISCLAIMER - This policy works when all resources of type aws_cloudfront_distribution and aws_cloudfront_origin_access_control are present in the root module.
+
+This control checks whether an Amazon CloudFront distribution with an Amazon S3 origin has origin access control (OAC) configured. The control fails if OAC isn't configured for the CloudFront distribution.
+
+When using an S3 bucket as an origin for your CloudFront distribution, you can enable OAC. This permits access to the content in the bucket only through the specified CloudFront distribution, and prohibits access directly from the bucket or another distribution. Although CloudFront supports Origin Access Identity (OAI), OAC offers additional functionality, and distributions using OAI can migrate to OAC. While OAI provides a secure way to access S3 origins, it has limitations, such as lack of support for granular policy configurations and for HTTP/HTTPS requests that use the POST method in AWS Regions that require AWS Signature Version 4 (SigV4). OAI also doesn't support encryption with AWS Key Management Service. OAC is based on an AWS best practice of using IAM service principals to authenticate with S3 origins.
+
+This rule is covered by the [cloudfront-s3-origin-access-control-enabled](../../policies/cloudfront/cloudfront-s3-origin-access-control-enabled.sentinel) policy.
+
+## Policy Results (Pass)
+```bash
+trace:
+
+    Pass - cloudfront-s3-origin-access-control-enabled.sentinel
+
+    Description:
+    This policy checks whether an 'aws_cloudfront_distribution' with an Amazon S3
+    origin has 'aws_cloudfront_origin_access_control' configured.
+
+    Print messages:
+
+    → → Overall Result: true
+
+    This result means that all resources have passed the policy check for the policy cloudfront-s3-origin-access-control-enabled.
+
+    ✓ Found 0 resource violations
+
+    cloudfront-s3-origin-access-control-enabled.sentinel:88:1 - Rule "main"
+    Value:
+        true
+
+```
+
+---
+
+## Policy Results (Fail)
+```bash
+trace:
+
+    Fail - cloudfront-s3-origin-access-control-enabled.sentinel
+
+    Description:
+    This policy checks whether an 'aws_cloudfront_distribution' with an Amazon S3
+    origin has 'aws_cloudfront_origin_access_control' configured.
+
+    Print messages:
+
+    → → Overall Result: false
+
+    This result means that not all resources passed the policy check and the protected behavior is not allowed for the policy cloudfront-s3-origin-access-control-enabled.
+
+    Found 1 resource violations
+
+    → Module name: root
+    ↳ Resource Address: aws_cloudfront_distribution.valid_origin
+        | ✗ failed
+        | 'aws_cloudfront_distribution' with an Amazon S3 origin has 'aws_cloudfront_origin_access_control' should have configured. Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/cloudfront-controls.html#cloudfront-13 for more details.
+
+
+    cloudfront-s3-origin-access-control-enabled.sentinel:88:1 - Rule "main"
+    Value:
+        false
+
+```
+---

--- a/policies/cloudfront/cloudfront-s3-origin-access-control-enabled.sentinel
+++ b/policies/cloudfront/cloudfront-s3-origin-access-control-enabled.sentinel
@@ -1,0 +1,90 @@
+// This policy checks whether an 'aws_cloudfront_distribution' with an Amazon S3 origin has 'aws_cloudfront_origin_access_control' configured.
+
+// Imports
+
+import "tfconfig/v2" as tfconfig
+import "tfresources" as tf
+import "report" as report
+import "collection" as collection
+import "collection/maps" as maps
+import "strings"
+
+// Constants
+
+const = {
+	"policy_name": "cloudfront-s3-origin-access-control-enabled",
+	"message":     "'aws_cloudfront_distribution' with an Amazon S3 origin has 'aws_cloudfront_origin_access_control' should have configured. Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/cloudfront-controls.html#cloudfront-13 for more details.",
+	"resource_aws_cloudfront_distribution": "aws_cloudfront_distribution",
+}
+
+// Functions
+
+get_origin_access_violations = func(res) {
+	origin_access_control_origin_type = maps.get(res[0].config, "origin_access_control_origin_type", {})
+	if origin_access_control_origin_type is empty {
+		return false
+	}
+	value = maps.get(origin_access_control_origin_type, "constant_value", "")
+	return value == "s3"
+}
+
+get_violations = func(resources) {
+	return collection.reject(resources, func(res) {
+		origin = maps.get(res.config, "origin", [])
+		if origin is empty {
+			return false
+		}
+		origin_access_control_id = maps.get(origin[0], "origin_access_control_id", [])
+		if origin_access_control_id is empty {
+			return false
+		}
+		references = maps.get(origin_access_control_id, "references", [])
+		if references is empty {
+			return false
+		}
+		for references as ref {
+			ref_split = strings.split(ref, ".")
+			if ref_split is empty or length(ref_split) < 2 {
+				return false
+			}
+			origin_access_control = ref_split[0] + "." + ref_split[1]
+			origin_access_control_resource = tf.config(tfconfig.resources).address(origin_access_control).resources
+			if origin_access_control_resource is empty {
+				return false
+			}
+			violation = get_origin_access_violations(origin_access_control_resource)
+			if !violation {
+				return false
+			}
+		}
+		return true
+	})
+}
+
+// Variables
+
+config_resources = tf.config(tfconfig.resources)
+cloudfront_distribution_resource = config_resources.type(const.resource_aws_cloudfront_distribution).resources
+
+violations = get_violations(cloudfront_distribution_resource)
+
+summary = {
+	"policy_name": const.policy_name,
+	"violations": map violations as _, v {
+		{
+			"address":        v.address,
+			"module_address": v.module_address,
+			"message":        const.message,
+		}
+	},
+}
+
+// Outputs
+
+print(report.generate_policy_report(summary))
+
+// Rules
+
+main = rule {
+	violations is empty
+}

--- a/policies/cloudfront/test/cloudfront-s3-origin-access-control-enabled/failure-origin-access-control-not-configured-with-s3.hcl
+++ b/policies/cloudfront/test/cloudfront-s3-origin-access-control-enabled/failure-origin-access-control-not-configured-with-s3.hcl
@@ -1,0 +1,24 @@
+mock "tfconfig/v2" {
+	module {
+		source = "./mocks/policy-failure-origin-access-control-not-configured-with-s3/mock-tfconfig-v2.sentinel"
+	}
+}
+
+
+mock "tfresources" {
+  module {
+    source = "../../../../modules/tfresources/tfresources.sentinel"
+  }
+}
+
+mock "report" {
+	module {
+		source = "../../../../modules/mocks/report/report.sentinel"
+	}
+}
+
+test {
+	rules = {
+		main = false
+	}
+}

--- a/policies/cloudfront/test/cloudfront-s3-origin-access-control-enabled/failure-origin-access-control-not-present.hcl
+++ b/policies/cloudfront/test/cloudfront-s3-origin-access-control-enabled/failure-origin-access-control-not-present.hcl
@@ -1,0 +1,24 @@
+mock "tfconfig/v2" {
+	module {
+		source = "./mocks/policy-failure-origin-access-control-not-present/mock-tfconfig-v2.sentinel"
+	}
+}
+
+
+mock "tfresources" {
+  module {
+    source = "../../../../modules/tfresources/tfresources.sentinel"
+  }
+}
+
+mock "report" {
+	module {
+		source = "../../../../modules/mocks/report/report.sentinel"
+	}
+}
+
+test {
+	rules = {
+		main = false
+	}
+}

--- a/policies/cloudfront/test/cloudfront-s3-origin-access-control-enabled/mocks/policy-failure-origin-access-control-not-configured-with-s3/mock-tfconfig-v2.sentinel
+++ b/policies/cloudfront/test/cloudfront-s3-origin-access-control-enabled/mocks/policy-failure-origin-access-control-not-configured-with-s3/mock-tfconfig-v2.sentinel
@@ -1,0 +1,153 @@
+import "strings"
+
+providers = {
+	"aws": {
+		"alias": "",
+		"config": {
+			"region": {
+				"constant_value": "us-east-1",
+			},
+		},
+		"full_name":           "registry.terraform.io/hashicorp/aws",
+		"module_address":      "",
+		"name":                "aws",
+		"provider_config_key": "aws",
+		"version_constraint":  "",
+	},
+}
+
+resources = {
+	"aws_cloudfront_distribution.valid_origin": {
+		"address": "aws_cloudfront_distribution.valid_origin",
+		"config": {
+			"default_cache_behavior": [
+				{
+					"allowed_methods": {
+						"constant_value": [
+							"GET",
+							"HEAD",
+						],
+					},
+					"cached_methods": {
+						"constant_value": [
+							"GET",
+							"HEAD",
+						],
+					},
+					"forwarded_values": [
+						{
+							"cookies": [
+								{
+									"forward": {
+										"constant_value": "none",
+									},
+								},
+							],
+							"query_string": {
+								"constant_value": false,
+							},
+						},
+					],
+					"target_origin_id": {
+						"constant_value": "S3Origin",
+					},
+					"viewer_protocol_policy": {
+						"constant_value": "redirect-to-https",
+					},
+				},
+			],
+			"default_root_object": {
+				"constant_value": "index.html",
+			},
+			"enabled": {
+				"constant_value": true,
+			},
+			"origin": [
+				{
+					"domain_name": {
+						"constant_value": "my-bucket.s3.us-east-1.amazonaws.com",
+					},
+					"origin_access_control_id": {
+						"references": [
+							"aws_cloudfront_origin_access_control.oac.id",
+							"aws_cloudfront_origin_access_control.oac",
+						],
+					},
+					"origin_id": {
+						"constant_value": "S3Origin",
+					},
+				},
+			],
+			"restrictions": [
+				{
+					"geo_restriction": [
+						{
+							"restriction_type": {
+								"constant_value": "none",
+							},
+						},
+					],
+				},
+			],
+			"viewer_certificate": [
+				{
+					"cloudfront_default_certificate": {
+						"constant_value": true,
+					},
+				},
+			],
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "valid_origin",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_cloudfront_distribution",
+	},
+	"aws_cloudfront_origin_access_control.oac": {
+		"address": "aws_cloudfront_origin_access_control.oac",
+		"config": {
+			"name": {
+				"constant_value": "example-oac",
+			},
+			"origin_access_control_origin_type": {
+				"constant_value": "lambda",
+			},
+			"signing_behavior": {
+				"constant_value": "always",
+			},
+			"signing_protocol": {
+				"constant_value": "sigv4",
+			},
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "oac",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_cloudfront_origin_access_control",
+	},
+}
+
+provisioners = {}
+
+variables = {}
+
+outputs = {}
+
+module_calls = {}
+
+strip_index = func(addr) {
+	s = strings.split(addr, ".")
+	for s as i, v {
+		s[i] = strings.split(v, "[")[0]
+	}
+
+	return strings.join(s, ".")
+}

--- a/policies/cloudfront/test/cloudfront-s3-origin-access-control-enabled/mocks/policy-failure-origin-access-control-not-present/mock-tfconfig-v2.sentinel
+++ b/policies/cloudfront/test/cloudfront-s3-origin-access-control-enabled/mocks/policy-failure-origin-access-control-not-present/mock-tfconfig-v2.sentinel
@@ -1,0 +1,121 @@
+import "strings"
+
+providers = {
+	"aws": {
+		"alias": "",
+		"config": {
+			"region": {
+				"constant_value": "us-east-1",
+			},
+		},
+		"full_name":           "registry.terraform.io/hashicorp/aws",
+		"module_address":      "",
+		"name":                "aws",
+		"provider_config_key": "aws",
+		"version_constraint":  "",
+	},
+}
+
+resources = {
+	"aws_cloudfront_distribution.valid_origin": {
+		"address": "aws_cloudfront_distribution.valid_origin",
+		"config": {
+			"default_cache_behavior": [
+				{
+					"allowed_methods": {
+						"constant_value": [
+							"GET",
+							"HEAD",
+						],
+					},
+					"cached_methods": {
+						"constant_value": [
+							"GET",
+							"HEAD",
+						],
+					},
+					"forwarded_values": [
+						{
+							"cookies": [
+								{
+									"forward": {
+										"constant_value": "none",
+									},
+								},
+							],
+							"query_string": {
+								"constant_value": false,
+							},
+						},
+					],
+					"target_origin_id": {
+						"constant_value": "S3Origin",
+					},
+					"viewer_protocol_policy": {
+						"constant_value": "redirect-to-https",
+					},
+				},
+			],
+			"default_root_object": {
+				"constant_value": "index.html",
+			},
+			"enabled": {
+				"constant_value": true,
+			},
+			"origin": [
+				{
+					"domain_name": {
+						"constant_value": "my-bucket.s3.us-east-1.amazonaws.com",
+					},
+					"origin_id": {
+						"constant_value": "S3Origin",
+					},
+				},
+			],
+			"restrictions": [
+				{
+					"geo_restriction": [
+						{
+							"restriction_type": {
+								"constant_value": "none",
+							},
+						},
+					],
+				},
+			],
+			"viewer_certificate": [
+				{
+					"cloudfront_default_certificate": {
+						"constant_value": true,
+					},
+				},
+			],
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "valid_origin",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_cloudfront_distribution",
+	},
+}
+
+provisioners = {}
+
+variables = {}
+
+outputs = {}
+
+module_calls = {}
+
+strip_index = func(addr) {
+	s = strings.split(addr, ".")
+	for s as i, v {
+		s[i] = strings.split(v, "[")[0]
+	}
+
+	return strings.join(s, ".")
+}

--- a/policies/cloudfront/test/cloudfront-s3-origin-access-control-enabled/mocks/policy-success-origin-access-control-configured-with-s3/mock-tfconfig-v2.sentinel
+++ b/policies/cloudfront/test/cloudfront-s3-origin-access-control-enabled/mocks/policy-success-origin-access-control-configured-with-s3/mock-tfconfig-v2.sentinel
@@ -1,0 +1,153 @@
+import "strings"
+
+providers = {
+	"aws": {
+		"alias": "",
+		"config": {
+			"region": {
+				"constant_value": "us-east-1",
+			},
+		},
+		"full_name":           "registry.terraform.io/hashicorp/aws",
+		"module_address":      "",
+		"name":                "aws",
+		"provider_config_key": "aws",
+		"version_constraint":  "",
+	},
+}
+
+resources = {
+	"aws_cloudfront_distribution.valid_origin": {
+		"address": "aws_cloudfront_distribution.valid_origin",
+		"config": {
+			"default_cache_behavior": [
+				{
+					"allowed_methods": {
+						"constant_value": [
+							"GET",
+							"HEAD",
+						],
+					},
+					"cached_methods": {
+						"constant_value": [
+							"GET",
+							"HEAD",
+						],
+					},
+					"forwarded_values": [
+						{
+							"cookies": [
+								{
+									"forward": {
+										"constant_value": "none",
+									},
+								},
+							],
+							"query_string": {
+								"constant_value": false,
+							},
+						},
+					],
+					"target_origin_id": {
+						"constant_value": "S3Origin",
+					},
+					"viewer_protocol_policy": {
+						"constant_value": "redirect-to-https",
+					},
+				},
+			],
+			"default_root_object": {
+				"constant_value": "index.html",
+			},
+			"enabled": {
+				"constant_value": true,
+			},
+			"origin": [
+				{
+					"domain_name": {
+						"constant_value": "my-bucket.s3.us-east-1.amazonaws.com",
+					},
+					"origin_access_control_id": {
+						"references": [
+							"aws_cloudfront_origin_access_control.oac.id",
+							"aws_cloudfront_origin_access_control.oac",
+						],
+					},
+					"origin_id": {
+						"constant_value": "S3Origin",
+					},
+				},
+			],
+			"restrictions": [
+				{
+					"geo_restriction": [
+						{
+							"restriction_type": {
+								"constant_value": "none",
+							},
+						},
+					],
+				},
+			],
+			"viewer_certificate": [
+				{
+					"cloudfront_default_certificate": {
+						"constant_value": true,
+					},
+				},
+			],
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "valid_origin",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_cloudfront_distribution",
+	},
+	"aws_cloudfront_origin_access_control.oac": {
+		"address": "aws_cloudfront_origin_access_control.oac",
+		"config": {
+			"name": {
+				"constant_value": "example-oac",
+			},
+			"origin_access_control_origin_type": {
+				"constant_value": "s3",
+			},
+			"signing_behavior": {
+				"constant_value": "always",
+			},
+			"signing_protocol": {
+				"constant_value": "sigv4",
+			},
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "oac",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_cloudfront_origin_access_control",
+	},
+}
+
+provisioners = {}
+
+variables = {}
+
+outputs = {}
+
+module_calls = {}
+
+strip_index = func(addr) {
+	s = strings.split(addr, ".")
+	for s as i, v {
+		s[i] = strings.split(v, "[")[0]
+	}
+
+	return strings.join(s, ".")
+}

--- a/policies/cloudfront/test/cloudfront-s3-origin-access-control-enabled/success-origin-access-control-configured-with-s3.hcl
+++ b/policies/cloudfront/test/cloudfront-s3-origin-access-control-enabled/success-origin-access-control-configured-with-s3.hcl
@@ -1,0 +1,24 @@
+mock "tfconfig/v2" {
+	module {
+		source = "./mocks/policy-success-origin-access-control-configured-with-s3/mock-tfconfig-v2.sentinel"
+	}
+}
+
+
+mock "tfresources" {
+  module {
+    source = "../../../../modules/tfresources/tfresources.sentinel"
+  }
+}
+
+mock "report" {
+	module {
+		source = "../../../../modules/mocks/report/report.sentinel"
+	}
+}
+
+test {
+	rules = {
+		main = true
+	}
+}

--- a/sentinel.hcl
+++ b/sentinel.hcl
@@ -1115,3 +1115,8 @@ policy "elasticsearch-domains-should-have-atleast-three-data-nodes" {
   source = "./policies/elasticsearch/elasticsearch-domains-should-have-atleast-three-data-nodes.sentinel"
   enforcement_level = "advisory"
 }
+
+policy "cloudfront-s3-origin-access-control-enabled" {
+  source = "./policies/cloudfront/cloudfront-s3-origin-access-control-enabled.sentinel"
+  enforcement_level = "advisory"
+}

--- a/tests/acceptance/cloudfront-s3-origin-access-control-enabled/cases/origin-access-control-configured-with-s3/backend.tf
+++ b/tests/acceptance/cloudfront-s3-origin-access-control-enabled/cases/origin-access-control-configured-with-s3/backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  cloud {
+    workspaces {
+      name = "cloudfront-s3-origin-access-control-enabled"
+    }
+  }
+}

--- a/tests/acceptance/cloudfront-s3-origin-access-control-enabled/cases/origin-access-control-configured-with-s3/main.tf
+++ b/tests/acceptance/cloudfront-s3-origin-access-control-enabled/cases/origin-access-control-configured-with-s3/main.tf
@@ -1,0 +1,45 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+resource "aws_cloudfront_origin_access_control" "oac" {
+  name                              = "example-oac"
+  origin_access_control_origin_type = "s3"
+  signing_behavior                  = "always"
+  signing_protocol                  = "sigv4"
+}
+
+resource "aws_cloudfront_distribution" "valid_origin" {
+  origin {
+    domain_name              = "my-bucket.s3.us-east-1.amazonaws.com"
+    origin_id                = "S3Origin"
+    origin_access_control_id = aws_cloudfront_origin_access_control.oac.id
+  }
+
+  enabled             = true
+  default_root_object = "index.html"
+
+  default_cache_behavior {
+    allowed_methods        = ["GET", "HEAD"]
+    cached_methods         = ["GET", "HEAD"]
+    target_origin_id       = "S3Origin"
+    viewer_protocol_policy = "redirect-to-https"
+
+    forwarded_values {
+      query_string = false
+      cookies {
+        forward = "none"
+      }
+    }
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
+}

--- a/tests/acceptance/cloudfront-s3-origin-access-control-enabled/cases/origin-access-control-not-configured-with-s3/backend.tf
+++ b/tests/acceptance/cloudfront-s3-origin-access-control-enabled/cases/origin-access-control-not-configured-with-s3/backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  cloud {
+    workspaces {
+      name = "cloudfront-s3-origin-access-control-enabled"
+    }
+  }
+}

--- a/tests/acceptance/cloudfront-s3-origin-access-control-enabled/cases/origin-access-control-not-configured-with-s3/main.tf
+++ b/tests/acceptance/cloudfront-s3-origin-access-control-enabled/cases/origin-access-control-not-configured-with-s3/main.tf
@@ -1,0 +1,45 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+resource "aws_cloudfront_origin_access_control" "oac" {
+  name                              = "example-oac"
+  origin_access_control_origin_type = "lambda"
+  signing_behavior                  = "always"
+  signing_protocol                  = "sigv4"
+}
+
+resource "aws_cloudfront_distribution" "valid_origin" {
+  origin {
+    domain_name              = "my-bucket.s3.us-east-1.amazonaws.com"
+    origin_id                = "S3Origin"
+    origin_access_control_id = aws_cloudfront_origin_access_control.oac.id
+  }
+
+  enabled             = true
+  default_root_object = "index.html"
+
+  default_cache_behavior {
+    allowed_methods        = ["GET", "HEAD"]
+    cached_methods         = ["GET", "HEAD"]
+    target_origin_id       = "S3Origin"
+    viewer_protocol_policy = "redirect-to-https"
+
+    forwarded_values {
+      query_string = false
+      cookies {
+        forward = "none"
+      }
+    }
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
+}

--- a/tests/acceptance/cloudfront-s3-origin-access-control-enabled/cases/origin-access-control-not-present/backend.tf
+++ b/tests/acceptance/cloudfront-s3-origin-access-control-enabled/cases/origin-access-control-not-present/backend.tf
@@ -1,0 +1,7 @@
+terraform {
+  cloud {
+    workspaces {
+      name = "cloudfront-s3-origin-access-control-enabled"
+    }
+  }
+}

--- a/tests/acceptance/cloudfront-s3-origin-access-control-enabled/cases/origin-access-control-not-present/main.tf
+++ b/tests/acceptance/cloudfront-s3-origin-access-control-enabled/cases/origin-access-control-not-present/main.tf
@@ -1,0 +1,37 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+resource "aws_cloudfront_distribution" "valid_origin" {
+  origin {
+    domain_name = "my-bucket.s3.us-east-1.amazonaws.com"
+    origin_id   = "S3Origin"
+  }
+
+  enabled             = true
+  default_root_object = "index.html"
+
+  default_cache_behavior {
+    allowed_methods        = ["GET", "HEAD"]
+    cached_methods         = ["GET", "HEAD"]
+    target_origin_id       = "S3Origin"
+    viewer_protocol_policy = "redirect-to-https"
+
+    forwarded_values {
+      query_string = false
+      cookies {
+        forward = "none"
+      }
+    }
+  }
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "none"
+    }
+  }
+
+  viewer_certificate {
+    cloudfront_default_certificate = true
+  }
+}

--- a/tests/acceptance/cloudfront-s3-origin-access-control-enabled/test-config.hcl
+++ b/tests/acceptance/cloudfront-s3-origin-access-control-enabled/test-config.hcl
@@ -1,0 +1,24 @@
+name = "cloudfront-s3-origin-access-control-enabled"
+	
+disabled = false
+
+case "origin-access-control-not-present" {
+	path = "./cases/origin-access-control-not-present"
+	expectation {
+		result = false
+	}
+}
+
+case "origin-access-control-not-configured-with-s3" {
+	path = "./cases/origin-access-control-not-configured-with-s3"
+	expectation {
+		result = false
+	}
+}
+
+case "origin-access-control-configured-with-s3" {
+	path = "./cases/origin-access-control-configured-with-s3"
+	expectation {
+		result = true
+	}
+}


### PR DESCRIPTION
## Changes proposed in this PR:
- Added cloudfront-s3-origin-access-control-enabled

## Documentation
- [AWS Standard](https://docs.aws.amazon.com/securityhub/latest/userguide/cloudfront-controls.html#cloudfront-13)
- [Policy details](https://docs.aws.amazon.com/securityhub/latest/userguide/cloudfront-controls.html#cloudfront-13)

## AWS Provider version
<!-- Add information about the provider version against which the policy was tested/developed with. This will later help us when we deal with documentation.Add any nuances that you've observed around provider versions. For example, some attributes will only be present in a certain version of a provider and we need to clearly document that so that users use the expected version.-->

## How I've tested this PR:

## Checklist:
- [x] Tests added