### PR TITLE
Added efs-automatic-backups-enabled

### DIFF
--- a/docs/policies/efs-automatic-backups-enabled.md
+++ b/docs/policies/efs-automatic-backups-enabled.md
@@ -1,0 +1,67 @@
+# EFS file systems should have automatic backups enabled
+
+| Provider            | Category     |
+|---------------------|--------------|
+| Amazon Web Services | Recover      |
+
+## Description
+
+DISCLAIMER - This policy works when all resources of type aws_efs_file_system and aws_efs_backup_policy are present in the root module.
+
+This control checks whether an Amazon EFS file system has automatic backups enabled. This control fails if the EFS file system doesn't have automatic backups enabled.
+
+A data backup is a copy of your system, configuration, or application data that's stored separately from the original. Enabling regular backups helps you safeguard valuable data against unforeseen events like system failures, cyberattacks, or accidental deletions. Having a robust backup strategy also facilitates quicker recovery, business continuity, and peace of mind in the face of potential data loss.
+
+This rule is covered by the [efs-automatic-backups-enabled](https://github.com/hashicorp/policy-library-FSBP-Policy-Set-for-AWS-Terraform/blob/main/policies/efs/efs-automatic-backups-enabled.sentinel) policy.
+
+## Policy Results (Pass)
+```bash
+trace:
+    Pass - efs-automatic-backups-enabled.sentinel
+
+    Description:
+    This policy requires EFS file systems to have automatic backups enabled
+
+    Print messages:
+
+    → → Overall Result: true
+
+    This result means that all resources have passed the policy check for the policy efs-automatic-backups-enabled.
+
+    ✓ Found 0 resource violations
+
+    efs-automatic-backups-enabled.sentinel:90:1 - Rule "main"
+    Value:
+        true
+```
+
+---
+
+## Policy Results (Fail)
+```bash
+trace:
+    Fail - efs-automatic-backups-enabled.sentinel
+
+    Description:
+    This policy requires EFS file systems to have automatic backups enabled
+
+    Print messages:
+
+    → → Overall Result: false
+
+    This result means that not all resources passed the policy check and the protected behavior is not allowed for the policy efs-automatic-backups-enabled.
+
+    Found 1 resource violations
+
+    → Module name: root
+    ↳ Resource Address: aws_efs_file_system.first
+        | ✗ failed
+        | EFS file systems should have automatic backups enabled. Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/efs-controls.html#efs-7 for more details.
+
+
+    efs-automatic-backups-enabled.sentinel:90:1 - Rule "main"
+    Value:
+        false
+```
+
+---

--- a/policies/efs/efs-automatic-backups-enabled.sentinel
+++ b/policies/efs/efs-automatic-backups-enabled.sentinel
@@ -1,0 +1,92 @@
+# This policy requires EFS file systems to have automatic backups enabled
+
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: BUSL-1.1
+
+# Imports
+
+import "tfconfig/v2" as tfconfig
+import "tfresources" as tf
+import "report" as report
+import "collection" as collection
+import "collection/maps" as maps
+
+# Constants
+
+const = {
+	"policy_name":                    "efs-automatic-backups-enabled",
+	"message":                        "EFS file systems should have automatic backups enabled. Refer to https://docs.aws.amazon.com/securityhub/latest/userguide/efs-controls.html#efs-7 for more details.",
+	"resource_aws_efs_file_system":   "aws_efs_file_system",
+	"resource_aws_efs_backup_policy": "aws_efs_backup_policy",
+}
+
+// Functions
+
+get_all_efs_file_systems = func(resources) {
+	efs_file_system_resources = {}
+
+	for resources as res {
+		if res.type is const.resource_aws_efs_file_system {
+			efs_file_system_resources[res.address] = {
+				"address":        res.address,
+				"module_address": res.module_address,
+				"message":        const.message,
+			}
+		}
+	}
+
+	return efs_file_system_resources
+}
+
+get_violations = func(resources, efs_file_system_resources) {
+	for resources as res {
+		file_system_id = maps.get(res.config, "file_system_id", {})
+		references = maps.get(file_system_id, "references", [])
+		backup_policy = maps.get(res.config, "backup_policy", [])
+		backup_status = maps.get(backup_policy[0], "status", {})
+		backup_status_value = maps.get(backup_status, "constant_value", "")
+
+		if backup_status_value is "DISABLED" {
+			continue
+		}
+
+		for references as ref {
+			if ref in efs_file_system_resources {
+				delete(efs_file_system_resources, ref)
+				break
+			}
+		}
+	}
+
+	values = []
+	for efs_file_system_resources as key, value {
+		append(values, value)
+	}
+
+	return values
+}
+
+// Variables
+
+config_resources = tf.config(tfconfig.resources)
+
+efs_file_system = config_resources.type(const.resource_aws_efs_file_system).resources
+efs_backup_policy = config_resources.type(const.resource_aws_efs_backup_policy).resources
+
+efs_file_system_resources = get_all_efs_file_systems(efs_file_system)
+violations = get_violations(efs_backup_policy, efs_file_system_resources)
+
+summary = {
+	"policy_name": const.policy_name,
+	"violations":  violations,
+}
+
+// Outputs
+
+print(report.generate_policy_report(summary))
+
+// Rules
+
+main = rule {
+	violations is empty
+}

--- a/policies/efs/test/efs-automatic-backups-enabled/failure-backup-options-disabled-in-one-out-of-multiple.hcl
+++ b/policies/efs/test/efs-automatic-backups-enabled/failure-backup-options-disabled-in-one-out-of-multiple.hcl
@@ -1,0 +1,24 @@
+mock "tfconfig/v2" {
+	module {
+		source = "./mocks/policy-failure-backup-options-disabled-in-one-out-of-multiple/mock-tfconfig-v2.sentinel"
+	}
+}
+
+
+mock "tfresources" {
+  module {
+    source = "../../../../modules/tfresources/tfresources.sentinel"
+  }
+}
+
+mock "report" {
+  module {
+    source = "../../../../modules/mocks/report/report.sentinel"
+  }
+}
+
+test {
+	rules = {
+		main = false
+	}
+}

--- a/policies/efs/test/efs-automatic-backups-enabled/failure-backup-options-disabled.hcl
+++ b/policies/efs/test/efs-automatic-backups-enabled/failure-backup-options-disabled.hcl
@@ -1,0 +1,27 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+mock "tfconfig/v2" {
+	module {
+		source = "./mocks/policy-failure-backup-options-disabled/mock-tfconfig-v2.sentinel"
+	}
+}
+
+
+mock "tfresources" {
+  module {
+    source = "../../../../modules/tfresources/tfresources.sentinel"
+  }
+}
+
+mock "report" {
+  module {
+    source = "../../../../modules/mocks/report/report.sentinel"
+  }
+}
+
+test {
+	rules = {
+		main = false
+	}
+}

--- a/policies/efs/test/efs-automatic-backups-enabled/mocks/policy-failure-backup-options-disabled-in-one-out-of-multiple/mock-tfconfig-v2.sentinel
+++ b/policies/efs/test/efs-automatic-backups-enabled/mocks/policy-failure-backup-options-disabled-in-one-out-of-multiple/mock-tfconfig-v2.sentinel
@@ -1,0 +1,184 @@
+import "strings"
+
+providers = {
+	"aws": {
+		"alias": "",
+		"config": {
+			"region": {
+				"constant_value": "us-west-2",
+			},
+		},
+		"full_name":           "registry.terraform.io/hashicorp/aws",
+		"module_address":      "",
+		"name":                "aws",
+		"provider_config_key": "aws",
+		"version_constraint":  "",
+	},
+}
+
+resources = {
+	"aws_efs_backup_policy.first_policy": {
+		"address": "aws_efs_backup_policy.first_policy",
+		"config": {
+			"backup_policy": [
+				{
+					"status": {
+						"constant_value": "DISABLED",
+					},
+				},
+			],
+			"file_system_id": {
+				"references": [
+					"aws_efs_file_system.first.id",
+					"aws_efs_file_system.first",
+				],
+			},
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "first_policy",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_efs_backup_policy",
+	},
+	"aws_efs_backup_policy.second_policy": {
+		"address": "aws_efs_backup_policy.second_policy",
+		"config": {
+			"backup_policy": [
+				{
+					"status": {
+						"constant_value": "ENABLED",
+					},
+				},
+			],
+			"file_system_id": {
+				"references": [
+					"aws_efs_file_system.second.id",
+					"aws_efs_file_system.second",
+				],
+			},
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "second_policy",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_efs_backup_policy",
+	},
+	"aws_efs_backup_policy.third_policy": {
+		"address": "aws_efs_backup_policy.third_policy",
+		"config": {
+			"backup_policy": [
+				{
+					"status": {
+						"constant_value": "ENABLED",
+					},
+				},
+			],
+			"file_system_id": {
+				"references": [
+					"aws_efs_file_system.third.id",
+					"aws_efs_file_system.third",
+				],
+			},
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "third_policy",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_efs_backup_policy",
+	},
+	"aws_efs_file_system.first": {
+		"address": "aws_efs_file_system.first",
+		"config": {
+			"creation_token": {
+				"constant_value": "my-product",
+			},
+			"tags": {
+				"constant_value": {
+					"Name": "MyProduct",
+				},
+			},
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "first",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_efs_file_system",
+	},
+	"aws_efs_file_system.second": {
+		"address": "aws_efs_file_system.second",
+		"config": {
+			"creation_token": {
+				"constant_value": "my-product",
+			},
+			"tags": {
+				"constant_value": {
+					"Name": "MyProduct",
+				},
+			},
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "second",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_efs_file_system",
+	},
+	"aws_efs_file_system.third": {
+		"address": "aws_efs_file_system.third",
+		"config": {
+			"creation_token": {
+				"constant_value": "my-product",
+			},
+			"tags": {
+				"constant_value": {
+					"Name": "MyProduct",
+				},
+			},
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "third",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_efs_file_system",
+	},
+}
+
+provisioners = {}
+
+variables = {}
+
+outputs = {}
+
+module_calls = {}
+
+strip_index = func(addr) {
+	s = strings.split(addr, ".")
+	for s as i, v {
+		s[i] = strings.split(v, "[")[0]
+	}
+
+	return strings.join(s, ".")
+}

--- a/policies/efs/test/efs-automatic-backups-enabled/mocks/policy-failure-backup-options-disabled/mock-tfconfig-v2.sentinel
+++ b/policies/efs/test/efs-automatic-backups-enabled/mocks/policy-failure-backup-options-disabled/mock-tfconfig-v2.sentinel
@@ -1,0 +1,86 @@
+import "strings"
+
+providers = {
+	"aws": {
+		"alias": "",
+		"config": {
+			"region": {
+				"constant_value": "us-west-2",
+			},
+		},
+		"full_name":           "registry.terraform.io/hashicorp/aws",
+		"module_address":      "",
+		"name":                "aws",
+		"provider_config_key": "aws",
+		"version_constraint":  "",
+	},
+}
+
+resources = {
+	"aws_efs_backup_policy.policy": {
+		"address": "aws_efs_backup_policy.policy",
+		"config": {
+			"backup_policy": [
+				{
+					"status": {
+						"constant_value": "DISABLED",
+					},
+				},
+			],
+			"file_system_id": {
+				"references": [
+					"aws_efs_file_system.foo.id",
+					"aws_efs_file_system.foo",
+				],
+			},
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "policy",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_efs_backup_policy",
+	},
+	"aws_efs_file_system.foo": {
+		"address": "aws_efs_file_system.foo",
+		"config": {
+			"creation_token": {
+				"constant_value": "my-product",
+			},
+			"tags": {
+				"constant_value": {
+					"Name": "MyProduct",
+				},
+			},
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "foo",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_efs_file_system",
+	},
+}
+
+provisioners = {}
+
+variables = {}
+
+outputs = {}
+
+module_calls = {}
+
+strip_index = func(addr) {
+	s = strings.split(addr, ".")
+	for s as i, v {
+		s[i] = strings.split(v, "[")[0]
+	}
+
+	return strings.join(s, ".")
+}

--- a/policies/efs/test/efs-automatic-backups-enabled/mocks/policy-success-backup-options-enabled/mock-tfconfig-v2.sentinel
+++ b/policies/efs/test/efs-automatic-backups-enabled/mocks/policy-success-backup-options-enabled/mock-tfconfig-v2.sentinel
@@ -1,0 +1,86 @@
+import "strings"
+
+providers = {
+	"aws": {
+		"alias": "",
+		"config": {
+			"region": {
+				"constant_value": "us-west-2",
+			},
+		},
+		"full_name":           "registry.terraform.io/hashicorp/aws",
+		"module_address":      "",
+		"name":                "aws",
+		"provider_config_key": "aws",
+		"version_constraint":  "",
+	},
+}
+
+resources = {
+	"aws_efs_backup_policy.policy": {
+		"address": "aws_efs_backup_policy.policy",
+		"config": {
+			"backup_policy": [
+				{
+					"status": {
+						"constant_value": "ENABLED",
+					},
+				},
+			],
+			"file_system_id": {
+				"references": [
+					"aws_efs_file_system.foo.id",
+					"aws_efs_file_system.foo",
+				],
+			},
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "policy",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_efs_backup_policy",
+	},
+	"aws_efs_file_system.foo": {
+		"address": "aws_efs_file_system.foo",
+		"config": {
+			"creation_token": {
+				"constant_value": "my-product",
+			},
+			"tags": {
+				"constant_value": {
+					"Name": "MyProduct",
+				},
+			},
+		},
+		"count":               {},
+		"depends_on":          [],
+		"for_each":            {},
+		"mode":                "managed",
+		"module_address":      "",
+		"name":                "foo",
+		"provider_config_key": "aws",
+		"provisioners":        [],
+		"type":                "aws_efs_file_system",
+	},
+}
+
+provisioners = {}
+
+variables = {}
+
+outputs = {}
+
+module_calls = {}
+
+strip_index = func(addr) {
+	s = strings.split(addr, ".")
+	for s as i, v {
+		s[i] = strings.split(v, "[")[0]
+	}
+
+	return strings.join(s, ".")
+}

--- a/policies/efs/test/efs-automatic-backups-enabled/success-backup-options-enabled.hcl
+++ b/policies/efs/test/efs-automatic-backups-enabled/success-backup-options-enabled.hcl
@@ -1,0 +1,27 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+mock "tfconfig/v2" {
+	module {
+		source = "./mocks/policy-success-backup-options-enabled/mock-tfconfig-v2.sentinel"
+	}
+}
+
+
+mock "tfresources" {
+  module {
+    source = "../../../../modules/tfresources/tfresources.sentinel"
+  }
+}
+
+mock "report" {
+  module {
+    source = "../../../../modules/mocks/report/report.sentinel"
+  }
+}
+
+test {
+	rules = {
+		main = true
+	}
+}

--- a/sentinel.hcl
+++ b/sentinel.hcl
@@ -1194,8 +1194,12 @@ policy "autoscaling-group-should-use-multiple-instance-types" {
   enforcement_level = "advisory"
 }
 
-
 policy "sqs-queue-block-public-access" {
   source = "./policies/sqs/sqs-queue-block-public-access.sentinel"
+  enforcement_level = "advisory"
+}
+
+policy "efs-automatic-backups-enabled" {
+  source = "./policies/efs/efs-automatic-backups-enabled.sentinel"
   enforcement_level = "advisory"
 }


### PR DESCRIPTION
## Changes proposed in this PR:
- Added efs-automatic-backups-enabled

## Documentation
- [AWS Standard](https://docs.aws.amazon.com/securityhub/latest/userguide/efs-controls.html#efs-7)
- [Policy details](https://docs.aws.amazon.com/securityhub/latest/userguide/efs-controls.html#efs-7)

## AWS Provider version
<!-- Add information about the provider version against which the policy was tested/developed with. This will later help us when we deal with documentation.Add any nuances that you've observed around provider versions. For example, some attributes will only be present in a certain version of a provider and we need to clearly document that so that users use the expected version.-->

## How I've tested this PR:

## Checklist:
- [ ] Tests added