### PR TITLE
Modified the CI workflow to use hashicorp/setup-sentinel instead of bloominlabs workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.1.5
       - name: Install Sentinel
-        uses: bloominlabs/setup-hashicorp-releases@47e70332de2225670dedad7833c0e19229f751b5
+        uses: hashicorp/setup-sentinel@main
+        id: setup
         with:
-          package: sentinel
           version: ${{ inputs.sentinel-version }}
       - name: Sentinel Format
         run: |


### PR DESCRIPTION
## Changes proposed in this PR:
- Modified the CI workflow to use hashicorp/setup-sentinel instead of bloominlabs workflow
-