### PR TITLE
Update LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -3,22 +3,22 @@ License text copyright (c) 2020 MariaDB Corporation Ab, All Rights Reserved.
 
 Parameters
 
-Licensor:             HashiCorp, Inc.
+Licensor:             International Business Machines Corporation (IBM)
 Licensed Work:        Policy Library FSBP AWS IAM Terraform. The Licensed Work is (c) 2024
-                      HashiCorp, Inc.
+                      IBM Corp.
 Additional Use Grant: You may make production use of the Licensed Work, provided
                       Your use does not include offering the Licensed Work to third
                       parties on a hosted or embedded basis in order to compete with 
-                      HashiCorp's paid version(s) of the Licensed Work. For purposes 
+                      IBM Corp's paid version(s) of the Licensed Work. For purposes 
                       of this license:
 
                       A "competitive offering" is a Product that is offered to third
                       parties on a paid basis, including through paid support 
                       arrangements, that significantly overlaps with the capabilities 
-                      of HashiCorp's paid version(s) of the Licensed Work. If Your 
+                      of IBM Corp's paid version(s) of the Licensed Work. If Your 
                       Product is not a competitive offering when You first make it 
                       generally available, it will not become a competitive offering
-                      later due to HashiCorp releasing a new version of the Licensed 
+                      later due to IBM Corp releasing a new version of the Licensed 
                       Work with additional capabilities. In addition, Products that 
                       are not provided on a paid basis are not competitive.
 
@@ -34,10 +34,10 @@ Additional Use Grant: You may make production use of the Licensed Work, provided
 
                       Hosting or using the Licensed Work(s) for internal purposes 
                       within an organization is not considered a competitive 
-                      offering. HashiCorp considers your organization to include all 
+                      offering. IBM Corp considers your organization to include all 
                       of your affiliates under common control.
 
-                      For binding interpretive guidance on using HashiCorp products 
+                      For binding interpretive guidance on using IBM Corp products 
                       under the Business Source License, please visit our FAQ. 
                       (https://www.hashicorp.com/license-faq)
 Change Date:          Four years from the date the Licensed Work is published.


### PR DESCRIPTION
Updates LICENSE text to replace HashiCorp references with IBM wording in the license document.